### PR TITLE
Addition of issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Create a bug report
+title: "[Bug] <Bug description here>"
+labels: bug
+assignees: ''
+
+---
+
+## **Description** 
+A clear and concise description of what the bug is.
+
+---
+## **Steps to Reproduce** 
+Provide a step-by-step guide to reproduce the issue:
+1. Step 1
+2. Step 2
+3. ...
+
+Make sure that the issue is reproducible when using a virtual environment with the expected dependencies and versions. 
+
+If possible, a minimal reproducible example code: 
+
+**Example Code**:
+```python
+# Add a minimal reproducible example here
+```
+
+---
+
+## **Expected behavior**
+A clear and concise description of what you expected to happen.
+
+--- 
+
+## **Actual behavior**
+
+Describe what actually happened. Include error messages, stack traces, logs or screenshots if possible.
+
+---
+
+## **(Optional) Possible cause**
+If you have an idea about the possible cause, describe it here.
+
+--- 
+
+## **Contributor willingness**
+
+- [ ] I am willing to help investigate and potentially fix this issue.
+- [ ] I am unable to contribute at this time.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,40 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: "[Feature] <Short description of the feature>"
+labels: enhancement
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## **Overview**
+Provide a high-level summary of the feature. Explain what the feature is and why it would be valuable for the library.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+---
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+## **Problem Statement**
+Describe the specific problem or limitation you are facing that this feature aims to solve. Why is this problem important? If possible, provide examples or use cases to illustrate the need for the feature.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+---
+
+## **Proposed Solution**
+Explain how the feature should be implemented. If possible include:
+- A description of the functionality.
+- Specific components or modules that would be affected.
+- Any relevant details or constraints.
+
+If you have a draft implementation (such as a feature branch in a fork), link it here.
+
+---
+
+## **(Optional) References and Resources**
+List any resources or references, for this feature. This can include:
+- Relevant research papers, articles, or blog posts
+- Examples of similar features in other libraries or tools
+- Related GitHub issues or discussions
+
+---
+
+## **Contributor Willingness**
+- [ ] I am willing to contribute to this feature.
+- [ ] I am unable to contribute at this time.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ## **Overview**
-Provide a high-level summary of the feature. Explain what the feature is and why it would be valuable for the library.
+Provide a high-level summary of the feature.
 
 ---
 


### PR DESCRIPTION
## Proposal

Addition of pre-defined templates for future issues.

## Goal 

Standardize the review of issues, such as bug reports and feature additions, by providing templates. This would facilitate the review for the maintainers. 

## Details

The `.md` files in `mfai/.github/ISSUE_TEMPLATE` allow users to select pre-defined templates to fill up their issues when opening issues via GitHub. Potentially, in the repo's setting, the option to submit blank issues can be removed, forcing the users to use a template. 

I proposed a template for bug reports and one for feature requests. The `YAML` part of the files is not displayed and is only used by GitHub (e.g to already assign the bug label to bug reports). To preview the template without merging into main and trying to submit an issue, a markdown render is enough to give you an idea. Unfortunately, being able to select a template when submitting an issue is linked to the default branch, and testing them in a feature branch is not possible as far as I know. 

I am very open to any suggestion on the content of the templates. Let me know your opition. 

## Other

It would be interesting to consider automatically assigning a maintainer to each new issue for review. This should be possible via GitHub actions. 
