### PR TITLE
Fix tiktoken encoding access for gpt2 tokenizer

### DIFF
--- a/mfai/encoding.py
+++ b/mfai/encoding.py
@@ -1,0 +1,39 @@
+"""Wrapper of tiktoken.get_encoding to retrieve tokenizer files from disk.
+Usefull for machines that don't have access to the internet."""
+
+import os
+from pathlib import Path
+
+tiktoken_cache_dir = Path(__file__).parent / "tokenizer" / "tiktoken_cache"
+os.environ["TIKTOKEN_CACHE_DIR"] = str(tiktoken_cache_dir)
+
+import tiktoken_ext.openai_public  # noqa
+import inspect  # noqa
+import hashlib  # noqa
+import tiktoken  # noqa
+
+available_tokenizers = {"gpt2": tiktoken_ext.openai_public.gpt2}
+
+
+def get_tiktoken_encoding(tokenizer_name: str) -> tiktoken.Encoding:
+    """Wrapper of tiktoken.get_encoding to retrieve tokenizer files from disk."""
+    if tokenizer_name not in available_tokenizers:
+        raise ValueError(
+            f"Tokenizer {tokenizer_name} is not available. {available_tokenizers} are available."
+        )
+    blobpath = inspect.getsource(available_tokenizers[tokenizer_name])
+
+    vocab_bpe_url = blobpath.split('"')[1]
+    cache_key_vocab = hashlib.sha1(vocab_bpe_url.encode()).hexdigest()
+    vocab_path = tiktoken_cache_dir / cache_key_vocab
+
+    encoder_json_url = blobpath.split('"')[3]
+    cache_key_encoder = hashlib.sha1(encoder_json_url.encode()).hexdigest()
+    encoder_path = tiktoken_cache_dir / cache_key_encoder
+
+    if not vocab_path.exists() or not encoder_path.exists():
+        raise FileNotFoundError(
+            f"Missing some files for the {tokenizer_name} tokenizer: {vocab_path} and {encoder_path}"
+        )
+
+    return tiktoken.get_encoding(tokenizer_name)

--- a/mfai/encoding.py
+++ b/mfai/encoding.py
@@ -1,9 +1,10 @@
 """Wrapper of tiktoken.get_encoding to retrieve tokenizer files from disk.
-Usefull for machines that don't have access to the internet."""
+Usefull for machines which are behind a proxy."""
 
 import os
 from pathlib import Path
 
+# Define the cache dir for tiktoken lib
 tiktoken_cache_dir = Path(__file__).parent / "tokenizer" / "tiktoken_cache"
 os.environ["TIKTOKEN_CACHE_DIR"] = str(tiktoken_cache_dir)
 
@@ -21,19 +22,32 @@ def get_tiktoken_encoding(tokenizer_name: str) -> tiktoken.Encoding:
         raise ValueError(
             f"Tokenizer {tokenizer_name} is not available. {available_tokenizers} are available."
         )
+
+    # First we want to check that the encoding files are in the cache dir
+    # but the desired files have specific hashed names that we need to retrieve
+
+    # 1. Inspect the request that is made to openai through tiktoken
     blobpath = inspect.getsource(available_tokenizers[tokenizer_name])
 
+    # 2. Extract the url of the desired vocab file
     vocab_bpe_url = blobpath.split('"')[1]
+
+    # 3. Compute the hash name of this file
     cache_key_vocab = hashlib.sha1(vocab_bpe_url.encode()).hexdigest()
+
+    # 4. Define the path where the hashed file should be stored
     vocab_path = tiktoken_cache_dir / cache_key_vocab
 
+    # 5. Same steps for the encoder file
     encoder_json_url = blobpath.split('"')[3]
     cache_key_encoder = hashlib.sha1(encoder_json_url.encode()).hexdigest()
     encoder_path = tiktoken_cache_dir / cache_key_encoder
 
+    # 6. Check that we have all the needed files
     if not vocab_path.exists() or not encoder_path.exists():
         raise FileNotFoundError(
             f"Missing some files for the {tokenizer_name} tokenizer: {vocab_path} and {encoder_path}"
         )
 
+    # 7. Load the encoding through the cache dir
     return tiktoken.get_encoding(tokenizer_name)

--- a/mfai/tokenizers.py
+++ b/mfai/tokenizers.py
@@ -3,12 +3,14 @@ Module with various LLM tokenizers wrapped in a common interface.
 """
 
 from abc import ABC, abstractmethod
+from pathlib import Path
+
+import sentencepiece as spm
 import tiktoken
 import torch
-from pathlib import Path
-from huggingface_hub import hf_hub_download
-from huggingface_hub import login
-import sentencepiece as spm
+from huggingface_hub import hf_hub_download, login
+
+from mfai.encoding import get_tiktoken_encoding
 
 
 class Tokenizer(ABC):
@@ -38,7 +40,7 @@ class Tokenizer(ABC):
 
 class GPT2Tokenizer(Tokenizer):
     def __init__(self):
-        self.tokenizer = tiktoken.get_encoding("gpt2")
+        self.tokenizer = get_tiktoken_encoding("gpt2")
 
     def encode(self, text: str, *args, **kwargs) -> torch.Tensor:
         return self.tokenizer.encode(text, allowed_special={"<|endoftext|>"})

--- a/mfai/tokenizers.py
+++ b/mfai/tokenizers.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 import sentencepiece as spm
-import tiktoken
 import torch
 from huggingface_hub import hf_hub_download, login
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,7 @@
+from mfai.encoding import get_tiktoken_encoding
+
+
+def test_encoding():
+    encoding = get_tiktoken_encoding("gpt2")
+    code = encoding.encode("Hello, world")
+    assert code == [15496, 11, 995]


### PR DESCRIPTION
On machines without internet access, or behind a proxy, tiktoken can't download the necessary files to initialize the GPT2 tokenizer.
Now these files are stored in the repo and can be loaded from disk to initialize the tokenizer.