### PR TITLE
remove bare_tensor parameter from NamedTensor functions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Create a bug report
+title: "[Bug] <Bug description here>"
+labels: bug
+assignees: ''
+
+---
+
+## **Description** 
+A clear and concise description of what the bug is.
+
+---
+## **Steps to Reproduce** 
+Provide a step-by-step guide to reproduce the issue:
+1. Step 1
+2. Step 2
+3. ...
+
+Make sure that the issue is reproducible when using a virtual environment with the expected dependencies and versions. 
+
+If possible, a minimal reproducible example code: 
+
+**Example Code**:
+```python
+# Add a minimal reproducible example here
+```
+
+---
+
+## **Expected behavior**
+A clear and concise description of what you expected to happen.
+
+--- 
+
+## **Actual behavior**
+
+Describe what actually happened. Include error messages, stack traces, logs or screenshots if possible.
+
+---
+
+## **(Optional) Possible cause**
+If you have an idea about the possible cause, describe it here.
+
+--- 
+
+## **Contributor willingness**
+
+- [ ] I am willing to help investigate and potentially fix this issue.
+- [ ] I am unable to contribute at this time.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,40 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature] <Short description of the feature>"
+labels: enhancement
+assignees: ''
+
+---
+
+## **Overview**
+Provide a high-level summary of the feature.
+
+---
+
+## **Problem Statement**
+Describe the specific problem or limitation you are facing that this feature aims to solve. Why is this problem important? If possible, provide examples or use cases to illustrate the need for the feature.
+
+---
+
+## **Proposed Solution**
+Explain how the feature should be implemented. If possible include:
+- A description of the functionality.
+- Specific components or modules that would be affected.
+- Any relevant details or constraints.
+
+If you have a draft implementation (such as a feature branch in a fork), link it here.
+
+---
+
+## **(Optional) References and Resources**
+List any resources or references, for this feature. This can include:
+- Relevant research papers, articles, or blog posts
+- Examples of similar features in other libraries or tools
+- Related GitHub issues or discussions
+
+---
+
+## **Contributor Willingness**
+- [ ] I am willing to contribute to this feature.
+- [ ] I am unable to contribute at this time.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Except for LLMs and MLLMs, each model we provide is a subclass of [torch.nn.Modu
 - **features_last**: a boolean that indicates if the features dimension is the last dimension of the input/output tensor. If False, the features dimension is the second dimension of the input/output tensor.
 - **register**: a boolean that indicates if the model should be registered in the **MODELS** registry. By default, it is set to False which allows the creation of intermediate subclasses not meant for direct use.
 
-The Python interface contract for our model is enforced using [Python ABC](https://docs.python.org/3/library/abc.html) and in our case [ModelABC](mfai/torch/models/base.py#L1) class.
+The Python interface contract for our model is enforced using [Python ABC](https://docs.python.org/3/library/abc.html) and in our case [ModelABC](mfai/torch/models/base.py#L1) class. This class is combined to `torch.nn.Module` in [BaseModel](mfai/torch/models/base.py#L1).
 
 ```python
 @dataclass_json
@@ -115,7 +115,7 @@ class HalfUNetSettings:
     last_activation: str = "Identity"
     absolute_pos_embed: bool = False
 
-class HalfUNet(ModelABC, nn.Module):
+class HalfUNet(BaseModel):
     settings_kls = HalfUNetSettings
     onnx_supported: bool = True
     supported_num_spatial_dims = (2,)

--- a/doc/namedtensor.md
+++ b/doc/namedtensor.md
@@ -53,11 +53,11 @@ Returns the size of a dimension given its name.
 ### `__str__(self)`
 Returns a string representation of the **NamedTensor** with useful statistics.
 
-### `select(self, dim_name: str, index: int, bare_tensor: bool = True) -> Union[torch.Tensor, "NamedTensor"]`
-Returns the tensor indexed along the dimension `dim_name` with the desired index. The given dimension is removed from the tensor. If `bare_tensor` is `True`, a bare PyTorch tensor is returned; otherwise, a **NamedTensor** is returned.
+### `select(self, dim_name: str, index: int) -> "NamedTensor"`
+Returns the tensor indexed along the dimension `dim_name` with the desired index. The given dimension is removed from the tensor.
 
-### `index_select(self, dim_name: str, indices: torch.Tensor, bare_tensor: bool = True) -> Union[torch.Tensor, "NamedTensor"]`
-Returns the tensor indexed along the dimension `dim_name` with the indices tensor. The returned tensor has the same number of dimensions as the original tensor. The `dim_name` dimension has the same size as the length of `indices`; other dimensions have the same size as in the original tensor. If `bare_tensor` is `True`, a bare PyTorch tensor is returned; otherwise, a **NamedTensor** is returned.
+### `index_select(self, dim_name: str, indices: torch.Tensor) -> "NamedTensor"`
+Returns the tensor indexed along the dimension `dim_name` with the indices tensor. The returned tensor has the same number of dimensions as the original tensor. The `dim_name` dimension has the same size as the length of `indices`; other dimensions have the same size as in the original tensor.
 
 ### `new_like(cls, tensor: torch.Tensor, other: "NamedTensor") -> "NamedTensor"`
 Creates a new **NamedTensor** with the same names but different data.
@@ -77,8 +77,8 @@ Concatenates a list of **NamedTensor** instances along the features dimension.
 ### `stack(cls, tensors: List["NamedTensor"], dim_name: str, dim: int) -> "NamedTensor"`
 Stacks a list of **NamedTensor** instances along a new dimension.
 
-### `iter_dim(self, dim_name: str, bare_tensor: bool = True) -> Iterable[Union[torch.Tensor, "NamedTensor"]]`
-Iterates over the specified dimension, yielding either bare tensors or **NamedTensor** instances. If `bare_tensor` is `True`, bare PyTorch tensors are yielded; otherwise, **NamedTensor** instances are yielded.
+### `iter_dim(self, dim_name: str) -> Iterable["NamedTensor"]`
+Iterates over the specified dimension, yielding either bare tensors or **NamedTensor** instances.
 
 ### `type_(self, new_type)`
 Modifies the type of the underlying torch tensor by calling torch's `.type` method. This is an in-place operation for this class, the internal tensor is replaced by the new one.
@@ -164,12 +164,9 @@ nt = NamedTensor(
     feature_names=["u", "v", "t2m"],
 )
 
-# Iterate over the 'batch' dimension, yielding bare tensors
-for tensor in nt.iter_dim("batch", bare_tensor=True):
-    print(tensor.shape)
 
 # Iterate over the 'batch' dimension, yielding NamedTensor instances
-for named_tensor in nt.iter_dim("batch", bare_tensor=False):
+for named_tensor in nt.iter_dim("batch"):
     print(named_tensor)
 ```
 

--- a/mfai/torch/__init__.py
+++ b/mfai/torch/__init__.py
@@ -9,16 +9,20 @@ from torch import nn
 
 
 def to_numpy(tensor: torch.Tensor) -> numpy.ndarray:
-    return tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
+    return (
+        tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
+    )
 
 
-def export_to_onnx(model: nn.Module, sample: torch.Tensor | tuple[Any], filepath: Path | str) -> None:
+def export_to_onnx(
+    model: nn.Module, sample: torch.Tensor | tuple[Any], filepath: Path | str
+) -> None:
     """
     Exports a model to ONNX format.
     """
     if isinstance(sample, torch.Tensor):
         sample = (sample,)
-    
+
     if isinstance(filepath, Path):
         filepath = filepath.as_posix()
 

--- a/mfai/torch/dummy_dataset.py
+++ b/mfai/torch/dummy_dataset.py
@@ -237,7 +237,7 @@ class DummyMultiModalDataModule(LightningDataModule):
         return (
             NamedTensor.collate_fn(images),
             self.collate_text(input_txt),
-            self.collate_text(targets)
+            self.collate_text(targets),
         )
 
     def collate_text(

--- a/mfai/torch/lightning_modules/clip.py
+++ b/mfai/torch/lightning_modules/clip.py
@@ -1,6 +1,7 @@
 """
 LightningModule used to train a Clip model.
 """
+
 from typing import Literal, Tuple
 
 import lightning.pytorch as pl

--- a/mfai/torch/losses/perceptual.py
+++ b/mfai/torch/losses/perceptual.py
@@ -8,22 +8,24 @@ import torch.nn as nn
 import torchvision.models as models
 from urllib.error import URLError
 
+
 class PerceptualLoss(torch.nn.Module):
-    def __init__(self,
-                 device: str = 'cuda',
-                 multi_scale: bool = False,
-                 channel_iterative_mode: bool = True,
-                 in_channels: int = 3,
-                 pre_trained: bool = False,
-                 resize_input: bool = False,
-                 style_layer_ids: list = [],
-                 style_block_ids: list = [],
-                 feature_layer_ids: list = [4,9,16,23,30],
-                 feature_block_ids: list = [0,1,2,3,4],
-                 alpha_style: float = 0,
-                 alpha_feature: float = 1,
-        ) -> None:
-        r''' Class that computes the Perceptual Loss based on selected Network.
+    def __init__(
+        self,
+        device: str = "cuda",
+        multi_scale: bool = False,
+        channel_iterative_mode: bool = True,
+        in_channels: int = 3,
+        pre_trained: bool = False,
+        resize_input: bool = False,
+        style_layer_ids: list = [],
+        style_block_ids: list = [],
+        feature_layer_ids: list = [4, 9, 16, 23, 30],
+        feature_block_ids: list = [0, 1, 2, 3, 4],
+        alpha_style: float = 0,
+        alpha_feature: float = 1,
+    ) -> None:
+        r"""Class that computes the Perceptual Loss based on selected Network.
             For more details : See Johnson et al. - Perceptual losses for real-time style transfer and super-resolution.
             (https://arxiv.org/pdf/1603.08155)
 
@@ -38,7 +40,7 @@ class PerceptualLoss(torch.nn.Module):
                 - feature_layer_ids: (list) - Ids of Feature Layers used for Perceptual Loss (default = [4,9,16,23,30])
                 - alpha_style: (float) - Weight of Style Loss (default = 0)
                 - alpha_feature (float) - Weight of Feature Loss (default = 1)
-        
+
         Example :
         ```python
             # In case the target and input are different everytime
@@ -52,29 +54,29 @@ class PerceptualLoss(torch.nn.Module):
             perceptual_loss = perceptual_loss_class(inputs, targets)
 
         ```
-        
-        
-         '''
+
+
+        """
         super().__init__()
 
-        self.device=device
-        if 'cuda' in device and not torch.cuda.is_available() : 
-            self.device = 'cpu'
-        
+        self.device = device
+        if "cuda" in device and not torch.cuda.is_available():
+            self.device = "cpu"
+
         # Iteration over channels for perceptual loss
-        self.channel_iterative_mode = channel_iterative_mode # whether to iterates over the channel for perceptual loss
-        self.in_channels = in_channels # Number of input channel for VGG16
+        self.channel_iterative_mode = channel_iterative_mode  # whether to iterates over the channel for perceptual loss
+        self.in_channels = in_channels  # Number of input channel for VGG16
         self.pre_trained = pre_trained
         self.resize_input = resize_input
 
         # Memory for features
-        self.features_memory: list[list]=[]
-        self.styles_memory: list[list]=[] 
+        self.features_memory: list[list] = []
+        self.styles_memory: list[list] = []
 
         # Style layer
         self.style_layer_ids = style_layer_ids
-        self.style_block_ids=style_block_ids
-        self.feature_block_ids=feature_block_ids
+        self.style_block_ids = style_block_ids
+        self.feature_block_ids = feature_block_ids
         self.alpha_style = alpha_style
 
         # Features layers
@@ -84,128 +86,142 @@ class PerceptualLoss(torch.nn.Module):
         # Multi-scale mode
         self.multi_scale = multi_scale
         self.scaling_factor = [0]
-        if multi_scale :
+        if multi_scale:
             for i in range(3):
                 self.scaling_factor.append(2**i)
-        
+
         self._set_network()
 
-    def _set_blocks(self) -> list :
-        r''' Set the blocks of layers from the neural network 
-        
-        Return : 
+    def _set_blocks(self) -> list:
+        r"""Set the blocks of layers from the neural network
+
+        Return :
             blocks: (list)
-        '''
+        """
         blocks = []
-        
+
         if not self.channel_iterative_mode and self.in_channels != 3:
             # The VGG16 is adapted so that the first layer can receive the required number of channels.
-            layers = [nn.Conv2d(in_channels=self.in_channels, out_channels=64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1)).eval()]
+            layers = [
+                nn.Conv2d(
+                    in_channels=self.in_channels,
+                    out_channels=64,
+                    kernel_size=(3, 3),
+                    stride=(1, 1),
+                    padding=(1, 1),
+                ).eval()
+            ]
 
-            for id_layer in range(1, self.feature_layer_ids[0]+1):
+            for id_layer in range(1, self.feature_layer_ids[0] + 1):
                 layers.append(self.network.features[id_layer].eval())
 
             blocks.append(nn.Sequential(*layers))
 
-        else :
-            blocks.append(self.network.features[:self.feature_layer_ids[0]].eval())
+        else:
+            blocks.append(self.network.features[: self.feature_layer_ids[0]].eval())
 
-        for id in range(len(self.feature_layer_ids)-1):
-            blocks.append(self.network.features[self.feature_layer_ids[id]:self.feature_layer_ids[id+1]].eval())
-        
+        for id in range(len(self.feature_layer_ids) - 1):
+            blocks.append(
+                self.network.features[
+                    self.feature_layer_ids[id] : self.feature_layer_ids[id + 1]
+                ].eval()
+            )
+
         return blocks
-    
-    def _downscale(self,
-                  x : torch.Tensor,
-                  scale_times: int =1,
-                  mode: str='bilinear'
-        ) -> torch.Tensor :
-        
+
+    def _downscale(
+        self, x: torch.Tensor, scale_times: int = 1, mode: str = "bilinear"
+    ) -> torch.Tensor:
         for _ in range(scale_times):
             x = torch.nn.functional.interpolate(x, scale_factor=0.5, mode=mode)
 
         return x
-    
-    def _set_network(self) -> None :
-        r''' Set the VGG16 from torchvision.
-        
+
+    def _set_network(self) -> None:
+        r"""Set the VGG16 from torchvision.
+
         Trained version obtained : "https://download.pytorch.org/models/vgg16-397923af.pth"
-        '''
-        self.size_resize=[224,224]
-        self.network =  models.vgg16(weights=None if not self.pre_trained else self.pre_trained).to(self.device)
-        
-        blocks =  self._set_blocks()
+        """
+        self.size_resize = [224, 224]
+        self.network = models.vgg16(
+            weights=None if not self.pre_trained else self.pre_trained
+        ).to(self.device)
+
+        blocks = self._set_blocks()
 
         for bl in blocks:
             for p in bl.parameters():
                 p.requires_grad = False
 
         self.blocks = torch.nn.ModuleList(blocks)
-    
-    def _forward_net_single_img(self,
-                               x: torch.Tensor
-        ) -> tuple :
-        r''' Forward the Network features and styles for a single image. 
+
+    def _forward_net_single_img(self, x: torch.Tensor) -> tuple:
+        r"""Forward the Network features and styles for a single image.
 
         Arguments :
             x: (torch.Tensor)
-            
-        Return : 
+
+        Return :
             features : (list)
             styles : (list)
-        '''
+        """
 
         # if shape is (B,H,W)
-        if len(x.shape)==3 : 
+        if len(x.shape) == 3:
             x = x.unsqueeze(1)
 
         if self.channel_iterative_mode:
-            if x.shape[1] == 1 :
+            if x.shape[1] == 1:
                 x = x.repeat(1, 3, 1, 1)
-            elif x.shape[1] != 3 :
-                raise ValueError(f'Excpecting input to have 3 channels but it has {x.shape[1]}')
-        else :
-            if x.shape[1] != self.in_channels :
-                raise ValueError(f'Expecting input to have {self.in_channels} channels but it has {x.shape[1]}')
-        
+            elif x.shape[1] != 3:
+                raise ValueError(
+                    f"Excpecting input to have 3 channels but it has {x.shape[1]}"
+                )
+        else:
+            if x.shape[1] != self.in_channels:
+                raise ValueError(
+                    f"Expecting input to have {self.in_channels} channels but it has {x.shape[1]}"
+                )
+
         if self.resize_input:
-            x = torch.nn.functional.interpolate(x, mode='bilinear', size=self.size_resize, align_corners=False)
+            x = torch.nn.functional.interpolate(
+                x, mode="bilinear", size=self.size_resize, align_corners=False
+            )
 
         features = []
-        styles= []
+        styles = []
 
         for i, block in enumerate(self.blocks):
             x = block(x)
             if i in self.feature_block_ids:
                 features.append(x)
-            if i in self.style_block_ids: 
+            if i in self.style_block_ids:
                 act_x = x.reshape(x.shape[0], x.shape[1], -1)
                 gram_x = act_x @ act_x.permute(0, 2, 1)
                 styles.append(gram_x)
-        
+
         return features, styles
-    
-    def compute_perceptual_features(self,
-                                    x: torch.Tensor,
-                                    return_features_and_styles:bool = False
-        ) -> tuple :
-        r''' Compute the features of a single image.
+
+    def compute_perceptual_features(
+        self, x: torch.Tensor, return_features_and_styles: bool = False
+    ) -> tuple:
+        r"""Compute the features of a single image.
 
         Arguments :
             x: (torch.Tensor)
             return_features_and_styles: (bool)
-        
+
         Example :
         ```python
             # In case you need to compare different targets to the same input
             inputs = torch.rand(25, 5, 128, 128)
             perceptual_loss_class = PerceptualLoss(channel_iterative_mode=True)
-            
+
             # The features of the inputs are computed and stored in the memory
             perceptual_loss_class.compute_perceptual_features(inputs)
-            
+
             for _ in range():
-                
+
                 targets = torch.rand(25, 5, 128, 128)
 
                 # The features of the targets are computed and compared to the input features
@@ -213,7 +229,7 @@ class PerceptualLoss(torch.nn.Module):
 
         ```
 
-        '''
+        """
         features = []
         styles = []
         for scaling_factor in self.scaling_factor:
@@ -222,99 +238,92 @@ class PerceptualLoss(torch.nn.Module):
 
             if self.channel_iterative_mode:
                 for channel_id in range(x.shape[1]):
-                    feature, style = self._forward_net_single_img(x[:, channel_id, :, :])
+                    feature, style = self._forward_net_single_img(
+                        x[:, channel_id, :, :]
+                    )
                     features.append(feature)
                     styles.append(style)
-            else :
+            else:
                 feature, style = self._forward_net_single_img(x)
                 features.append(feature)
                 styles.append(style)
 
-        self.features_memory=features
-        self.styles_memory=styles 
+        self.features_memory = features
+        self.styles_memory = styles
 
         if return_features_and_styles:
             return features, styles
-        else :
+        else:
             return None, None
 
-    
-    def _perceptual_loss_given_features_and_target(self,
-                                                  x: torch.Tensor,
-                                                  features_y: list,
-                                                  styles_y: list
-        ) -> torch.Tensor :
-        r''' Computes the Perceptual Loss given features and a target image.
+    def _perceptual_loss_given_features_and_target(
+        self, x: torch.Tensor, features_y: list, styles_y: list
+    ) -> torch.Tensor:
+        r"""Computes the Perceptual Loss given features and a target image.
 
         Arguments :
             x: (torch.Tensor)
             features_y : (list)
             styles_y : (list)
-        
+
         Return :
             loss : (troch.Tensor)
-        '''
+        """
 
         features_x, styles_x = self._forward_net_single_img(x)
 
-        loss = torch.tensor(0.).to(self.device)
+        loss = torch.tensor(0.0).to(self.device)
         for i, _ in enumerate(self.blocks):
             if i in self.feature_block_ids:
                 x = features_x[i]
                 y = features_y[i]
                 loss_features = torch.nn.functional.l1_loss(x, y)
-                loss += self.alpha_feature*loss_features
-            if i in self.style_block_ids: 
+                loss += self.alpha_feature * loss_features
+            if i in self.style_block_ids:
                 gram_x = styles_x[i]
                 gram_y = styles_y[i]
                 loss_style = torch.nn.functional.l1_loss(gram_x, gram_y)
-                loss += self.alpha_style*loss_style
+                loss += self.alpha_style * loss_style
         return loss
 
-    def _perceptual_loss_given_input_and_target(self,
-                                               x : torch.Tensor,
-                                               y : torch.Tensor
-        ) -> torch.Tensor :
-        r''' Computes the Perceptual Loss between two images 
-        
+    def _perceptual_loss_given_input_and_target(
+        self, x: torch.Tensor, y: torch.Tensor
+    ) -> torch.Tensor:
+        r"""Computes the Perceptual Loss between two images
+
         Arguments :
             x: (torch.Tensor)
             y: (torch.Tensor)
 
         Return :
-            loss : (troch.Tensor)'''
+            loss : (troch.Tensor)"""
 
         features_x, styles_x = self._forward_net_single_img(x)
 
         return self._perceptual_loss_given_features_and_target(
-            x=y,
-            features_y=features_x,
-            styles_y=styles_x
+            x=y, features_y=features_x, styles_y=styles_x
         )
 
-    def forward(self,
-                x: torch.Tensor,
-                y: torch.Tensor = None
-        ) -> torch.Tensor :
-        r''' Computes the Perceptual loss between two images 
+    def forward(self, x: torch.Tensor, y: torch.Tensor | None = None) -> torch.Tensor:
+        r"""Computes the Perceptual loss between two images
         Arguments :
             x: (torch.Tensor)
             y: (torch.Tensor) (default=None)
 
-        Note : 
+        Note :
             If y is None, the features of y needs to be computed before by calling the function : compute_perceptual_features
-            
-        '''
 
-        perceptual_loss = torch.tensor(0.).to(self.device)
+        """
 
-        # Check that tensors are normalized 
-        if x.max() > 1 or x.min() < 0 : 
-            raise ValueError('x data should be normalized between 0 and 1')
+        perceptual_loss = torch.tensor(0.0).to(self.device)
+
+        # Check that tensors are normalized
+        if x.max() > 1 or x.min() < 0:
+            raise ValueError("x data should be normalized between 0 and 1")
         elif y is not None:
-            if y.max() > 1 or y.min() < 0 : 
-                raise ValueError('y data should be normalized between 0 and 1')
-        else :
+            if y.max() > 1 or y.min() < 0:
+                raise ValueError("y data should be normalized between 0 and 1")
+        else:
             pass
 
         if y is not None:
@@ -322,96 +331,100 @@ class PerceptualLoss(torch.nn.Module):
                 if self.multi_scale:
                     x = self._downscale(x, scaling_factor)
                     y = self._downscale(y, scaling_factor)
-                    
+
                 if self.channel_iterative_mode:
                     for channel_id in range(x.shape[1]):
-                        perceptual_loss += self._perceptual_loss_given_input_and_target( 
-                            x = x[:, channel_id, :, :],
-                            y = y[:, channel_id, :, :]
+                        perceptual_loss += self._perceptual_loss_given_input_and_target(
+                            x=x[:, channel_id, :, :], y=y[:, channel_id, :, :]
                         )
                     perceptual_loss /= x.shape[1]
-                else :
-                    perceptual_loss += self._perceptual_loss_given_input_and_target( 
-                            x = x,
-                            y = y
-                        )
-        else :
-            if not (len(self.features_memory) and len(self.styles_memory)) :
-                print('Warning: The features needs to be computed before. To do so call the function : compute_perceptual_features ')
+                else:
+                    perceptual_loss += self._perceptual_loss_given_input_and_target(
+                        x=x, y=y
+                    )
+        else:
+            if not (len(self.features_memory) and len(self.styles_memory)):
+                print(
+                    "Warning: The features needs to be computed before. To do so call the function : compute_perceptual_features "
+                )
                 raise ValueError
             for id_scaling_factor, scaling_factor in enumerate(self.scaling_factor):
                 if self.multi_scale:
                     x = self._downscale(x, scaling_factor)
-                else :
+                else:
                     id_scaling_factor = 0
                 if self.channel_iterative_mode:
                     for channel_id in range(x.shape[1]):
-                        features_y=self.features_memory[id_scaling_factor*x.shape[1]+channel_id]
+                        features_y = self.features_memory[
+                            id_scaling_factor * x.shape[1] + channel_id
+                        ]
                         if len(self.style_layer_ids):
-                            styles_y=self.styles_memory[id_scaling_factor*x.shape[1]+channel_id]
-                        else :
-                            styles_y=[]
-                        perceptual_loss += self._perceptual_loss_given_features_and_target(
-                            x=x[:, channel_id, :, :],
-                            features_y=features_y, 
-                            styles_y=styles_y
+                            styles_y = self.styles_memory[
+                                id_scaling_factor * x.shape[1] + channel_id
+                            ]
+                        else:
+                            styles_y = []
+                        perceptual_loss += (
+                            self._perceptual_loss_given_features_and_target(
+                                x=x[:, channel_id, :, :],
+                                features_y=features_y,
+                                styles_y=styles_y,
+                            )
                         )
                     perceptual_loss /= x.shape[1]
-                else :
-
-                    features_y=self.features_memory[id_scaling_factor]
+                else:
+                    features_y = self.features_memory[id_scaling_factor]
                     if len(self.style_layer_ids):
-                        styles_y=self.styles_memory[id_scaling_factor]
-                    else :
-                        styles_y=[]
+                        styles_y = self.styles_memory[id_scaling_factor]
+                    else:
+                        styles_y = []
 
                     perceptual_loss += self._perceptual_loss_given_features_and_target(
                         x=x,
-                        features_y=features_y, 
+                        features_y=features_y,
                         styles_y=styles_y,
                     )
 
-            
         return perceptual_loss
 
 
-
 class LPIPS(nn.Module):
-    r''' Creates a criterion that measures Learned Perceptual Image Patch Similarity (LPIPS).
-        For more info see : Zhang et al. The Unreasonable Effectiveness of Deep Features as a Perceptual Metric 
-        (https://arxiv.org/pdf/1801.03924)
+    r"""Creates a criterion that measures Learned Perceptual Image Patch Similarity (LPIPS).
+    For more info see : Zhang et al. The Unreasonable Effectiveness of Deep Features as a Perceptual Metric
+    (https://arxiv.org/pdf/1801.03924)
 
-        This code is inspired from : https://github.com/richzhang/PerceptualSimilarity/
+    This code is inspired from : https://github.com/richzhang/PerceptualSimilarity/
 
-        Arguments :
-                device: (str) - Device where to store the Neural Network (default = 'cuda')
-                multi_scale: (bool) - Multi Scale mode to compute Perceptual Loss at different scales (default = False)
-                channel_iterative_mode: (bool) - To compute the Perceptual Loss over channels of the input (default = False)
-                in_channels: (int) - Number of input channels for perceptual Loss - [Used only if channel_iterative_mode=False] (default = 1)
-                pre_trained: (bool) - To use a pre-trained or a random version of the VGG16 (default = False)
-                resize_input: (bool) - To adapt input size to ImageNet Dataset size (224x224) (default = False)
-                style_layer_ids: (list) - Ids of Style Layers used for Perceptual Loss (default = [])
-                feature_layer_ids: (list) - Ids of Feature Layers used for Perceptual Loss (default = [4,9,16,23,30])
-                alpha_style: (float) - Weight of Style Loss (default = 0)
-                alpha_feature (float) - Weight of Feature Loss (default = 1)
-    '''
-    def __init__(self, 
-                 device: str = 'cuda',
-                 multi_scale: bool = False,
-                 channel_iterative_mode: bool = False,
-                 in_channels: int = 3,
-                 pre_trained: bool = False,
-                 resize_input: bool = False,
-                 style_layer_ids: list = [],
-                 style_block_ids: list = [],
-                 feature_layer_ids: list = [4,9,16,23,30],
-                 feature_block_ids: list = [0,1,2,3,4],
-                 alpha_style: float = 0,
-                 alpha_feature: float = 1
-        ) -> None :
+    Arguments :
+            device: (str) - Device where to store the Neural Network (default = 'cuda')
+            multi_scale: (bool) - Multi Scale mode to compute Perceptual Loss at different scales (default = False)
+            channel_iterative_mode: (bool) - To compute the Perceptual Loss over channels of the input (default = False)
+            in_channels: (int) - Number of input channels for perceptual Loss - [Used only if channel_iterative_mode=False] (default = 1)
+            pre_trained: (bool) - To use a pre-trained or a random version of the VGG16 (default = False)
+            resize_input: (bool) - To adapt input size to ImageNet Dataset size (224x224) (default = False)
+            style_layer_ids: (list) - Ids of Style Layers used for Perceptual Loss (default = [])
+            feature_layer_ids: (list) - Ids of Feature Layers used for Perceptual Loss (default = [4,9,16,23,30])
+            alpha_style: (float) - Weight of Style Loss (default = 0)
+            alpha_feature (float) - Weight of Feature Loss (default = 1)
+    """
+
+    def __init__(
+        self,
+        device: str = "cuda",
+        multi_scale: bool = False,
+        channel_iterative_mode: bool = False,
+        in_channels: int = 3,
+        pre_trained: bool = False,
+        resize_input: bool = False,
+        style_layer_ids: list = [],
+        style_block_ids: list = [],
+        feature_layer_ids: list = [4, 9, 16, 23, 30],
+        feature_block_ids: list = [0, 1, 2, 3, 4],
+        alpha_style: float = 0,
+        alpha_feature: float = 1,
+    ) -> None:
         super().__init__()
 
-        
         self.perceptual_loss = PerceptualLoss(
             device=device,
             multi_scale=multi_scale,
@@ -424,73 +437,83 @@ class LPIPS(nn.Module):
             feature_layer_ids=feature_layer_ids,
             feature_block_ids=feature_block_ids,
             alpha_style=alpha_style,
-            alpha_feature=alpha_feature
+            alpha_feature=alpha_feature,
         ).to(device)
 
         self.pre_trained = pre_trained
         self.device = device
-        
+
         n_channels_list = [64, 128, 256, 512, 512]
-        
+
         # linear layers
         self.lin = LinLayers(n_channels_list).to(device)
         self.lin.load_state_dict(self._get_state_dict())
-        try :
+        try:
             self.lin.load_state_dict(self._get_state_dict())
         except URLError:
-            print('The linear layers for LPIPS computation could not be downloaded. Please check SSL certificate.')
+            print(
+                "The linear layers for LPIPS computation could not be downloaded. Please check SSL certificate."
+            )
 
-        
-    def _get_state_dict(self, net_type: str = 'vgg16', version: str = '0.1') -> OrderedDict :
+    def _get_state_dict(
+        self, net_type: str = "vgg16", version: str = "0.1"
+    ) -> OrderedDict:
         # build url
-        url = 'https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/' \
-            + f'master/lpips/weights/v{version}/{net_type[:-2]}.pth'
+        url = (
+            "https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/"
+            + f"master/lpips/weights/v{version}/{net_type[:-2]}.pth"
+        )
 
         # download
         old_state_dict = torch.hub.load_state_dict_from_url(
-            url, progress=True,
-            map_location=self.device
+            url, progress=True, map_location=self.device
         )
 
         # rename keys
         new_state_dict = OrderedDict()
         for key, val in old_state_dict.items():
             new_key = key
-            new_key = new_key.replace('lin', '')
-            new_key = new_key.replace('model.', '')
+            new_key = new_key.replace("lin", "")
+            new_key = new_key.replace("model.", "")
             new_state_dict[new_key] = val
-        
+
         return new_state_dict
 
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        feat_x, _ = self.perceptual_loss.compute_perceptual_features(x, return_features_and_styles=True)
-        feat_y, _ = self.perceptual_loss.compute_perceptual_features(y, return_features_and_styles=True)
-        
+        feat_x, _ = self.perceptual_loss.compute_perceptual_features(
+            x, return_features_and_styles=True
+        )
+        feat_y, _ = self.perceptual_loss.compute_perceptual_features(
+            y, return_features_and_styles=True
+        )
+
         feat_x_list = []
         for xs in feat_x:
             for x in xs:
                 feat_x_list.append(x)
-        
+
         feat_y_list = []
         for xs in feat_y:
             for x in xs:
                 feat_y_list.append(x)
 
         diff = [(fx - fy) ** 2 for fx, fy in zip(feat_x_list, feat_y_list)]
-        res = [layer(difference).mean((2, 3), True) for difference, layer in zip(diff, self.lin)]
+        res = [
+            layer(difference).mean((2, 3), True)
+            for difference, layer in zip(diff, self.lin)
+        ]
 
         return torch.sum(torch.cat(res, 0)) / x.shape[0]
 
 
-
 class LinLayers(nn.ModuleList):
-    def __init__(self, n_channels_list: Sequence[int])  -> None :
-        super().__init__([
-            nn.Sequential(
-                nn.Identity(),
-                nn.Conv2d(nc, 1, 1, 1, 0, bias=False)
-            ) for nc in n_channels_list
-        ])
+    def __init__(self, n_channels_list: Sequence[int]) -> None:
+        super().__init__(
+            [
+                nn.Sequential(nn.Identity(), nn.Conv2d(nc, 1, 1, 1, 0, bias=False))
+                for nc in n_channels_list
+            ]
+        )
 
         for param in self.parameters():
             param.requires_grad = False
@@ -501,8 +524,8 @@ class BaseNet(nn.Module):
         super().__init__()
 
         # register buffer
-        self.mean = torch.Tensor([-.030, -.088, -.188])[None, :, None, None]
-        self.std = torch.Tensor([.458, .448, .450])[None, :, None, None]
+        self.mean = torch.Tensor([-0.030, -0.088, -0.188])[None, :, None, None]
+        self.std = torch.Tensor([0.458, 0.448, 0.450])[None, :, None, None]
 
     def set_requires_grad(self, state: bool) -> None:
         for param in chain(self.parameters(), self.buffers()):
@@ -514,11 +537,13 @@ class BaseNet(nn.Module):
     def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
         raise NotImplementedError
 
+
 def get_network(net_type: str) -> BaseNet:
-    if net_type == 'vgg':
+    if net_type == "vgg":
         return VGG16()
     else:
-        raise NotImplementedError('choose net_type from [alex, squeeze, vgg].')
+        raise NotImplementedError("choose net_type from [alex, squeeze, vgg].")
+
 
 class VGG16(BaseNet):
     def __init__(self) -> None:
@@ -543,25 +568,23 @@ class VGG16(BaseNet):
         return output
 
 
-def normalize_activation(x : torch.Tensor, eps : float =1e-10) -> torch.Tensor:
-    norm_factor = torch.sqrt(torch.sum(x ** 2, dim=1, keepdim=True))
+def normalize_activation(x: torch.Tensor, eps: float = 1e-10) -> torch.Tensor:
+    norm_factor = torch.sqrt(torch.sum(x**2, dim=1, keepdim=True))
     return x / (norm_factor + eps)
 
 
-def get_state_dict(dir : str, net_type : str = 'alex') -> OrderedDict:
-
+def get_state_dict(dir: str, net_type: str = "alex") -> OrderedDict:
     old_state_dict = torch.load(
-        dir+f'lpips/{net_type}.pth',
-        map_location=None if torch.cuda.is_available() else torch.device('cpu')
+        dir + f"lpips/{net_type}.pth",
+        map_location=None if torch.cuda.is_available() else torch.device("cpu"),
     )
 
     # rename keys
     new_state_dict = OrderedDict()
     for key, val in old_state_dict.items():
         new_key = key
-        new_key = new_key.replace('lin', '')
-        new_key = new_key.replace('model.', '')
+        new_key = new_key.replace("lin", "")
+        new_key = new_key.replace("model.", "")
         new_state_dict[new_key] = val
 
     return new_state_dict
-

--- a/mfai/torch/metrics.py
+++ b/mfai/torch/metrics.py
@@ -55,7 +55,7 @@ class FNR(Metric):
 class PR_AUC(Metric):
     """Area Under the Precsion-Recall Curve."""
 
-    def __init__(self, task: Literal['binary', 'multiclass', 'multilabel'] = "binary"):
+    def __init__(self, task: Literal["binary", "multiclass", "multilabel"] = "binary"):
         super().__init__()
         full_state_update = True  # noqa
         self.task = task
@@ -152,7 +152,13 @@ class CSINeighborood(Metric):
         If multiclass, takes int value in [0, nb_output_channels] interval.
         """
 
-        def compute_sub_results(preds: torch.Tensor, targets: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor,]:
+        def compute_sub_results(
+            preds: torch.Tensor, targets: torch.Tensor
+        ) -> tuple[
+            torch.Tensor,
+            torch.Tensor,
+            torch.Tensor,
+        ]:
             exp_targets = targets.type(torch.FloatTensor.dtype).to(device=self.device)
             targets_extend = self.binary_dilation_(exp_targets)
             true_positives = torch.sum((preds == 1) & (targets_extend == 1))

--- a/mfai/torch/models/__init__.py
+++ b/mfai/torch/models/__init__.py
@@ -1,6 +1,7 @@
 import importlib
 import pkgutil
 from pathlib import Path
+from types import ModuleType
 from typing import Optional, Tuple
 
 from torch import nn
@@ -9,16 +10,16 @@ from .base import AutoPaddingModel, ModelABC
 
 # Load all models from the torch.models package
 # which are ModelABC subclasses and have the register attribute set to True
-registry = dict()
-package = importlib.import_module("mfai.torch.models")
-for _, name, _ in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
-    module = importlib.import_module(name)
+registry: dict[str, type[ModelABC] | type[AutoPaddingModel]] = dict()
+package: ModuleType = importlib.import_module("mfai.torch.models")
+for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
+    module: ModuleType = importlib.import_module(module_info.name)
     for object_name, kls in module.__dict__.items():
         if (
             isinstance(kls, type)
             and issubclass(kls, ModelABC)
             and kls != ModelABC
-            and kls.register
+            and kls.register  # type: ignore[truthy-function]
         ):
             if kls.__name__ in registry:
                 raise ValueError(
@@ -29,9 +30,7 @@ all_nn_architectures = list(registry.values())
 
 
 autopad_nn_architectures = {
-    obj
-    for obj in all_nn_architectures
-    if issubclass(obj, AutoPaddingModel) and obj != "AutoPaddingModel"
+    obj for obj in all_nn_architectures if issubclass(obj, AutoPaddingModel)
 }
 
 
@@ -46,12 +45,24 @@ def load_from_settings_file(
     Instanciate a model from a settings file with Schema validation.
     """
 
-    # pick the class matching the supplied name
+    # Pick the class matching the supplied name
     model_kls = registry.get(model_name, None)
 
     if model_kls is None:
         raise ValueError(
             f"Model {model_name} not found in available architectures: {[x for x in registry]}. Make sure the model's `registry` attribute is set to True (default is False)."
+        )
+
+    # Check that the class is ModelABC subclass
+    if not (issubclass(model_kls, ModelABC) and issubclass(model_kls, nn.Module)):
+        raise ValueError(
+            f"Model {model_name} is not a subclass of mfai.torch.models.ModelABC and torch.nn.Module."
+        )
+
+    # Check that the model's settings class is wrapped by the @dataclass_json decorator by looking for the schema attribute
+    if not hasattr(model_kls.settings_kls, "schema"):
+        raise ValueError(
+            f"Model {model_name}.settings_kls has no attribute schema. Make sure the model's settings class is wrapped by the @dataclass_json decorator."
         )
 
     # load the settings

--- a/mfai/torch/models/__init__.py
+++ b/mfai/torch/models/__init__.py
@@ -2,7 +2,7 @@ import importlib
 import pkgutil
 from pathlib import Path
 from types import ModuleType
-from typing import Optional, Tuple
+
 
 from torch import nn
 
@@ -39,7 +39,7 @@ def load_from_settings_file(
     in_channels: int,
     out_channels: int,
     settings_path: Path,
-    input_shape: Optional[Tuple[int, ...]] = None,
+    input_shape: tuple[int, ...],
 ) -> nn.Module:
     """
     Instanciate a model from a settings file with Schema validation.

--- a/mfai/torch/models/base.py
+++ b/mfai/torch/models/base.py
@@ -4,7 +4,7 @@ Interface contract for our models.
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Tuple
 from torch import Size
 from torch import nn
 import torch
@@ -135,23 +135,24 @@ class AutoPaddingModel(ABC):
 
     def _maybe_padding(
         self, data_tensor: torch.Tensor
-    ) -> Tuple[Union[torch.Tensor, ValueError], Optional[torch.Size]]:
+    ) -> tuple[torch.Tensor, torch.Size]:
         """Performs an optional padding to ensure that the data tensor can be fed
-            to the underlying model. Padding will happen if if
+            to the underlying model. Padding will happen only if
             autopadding was enabled via the settings.
 
         Args:
             data_tensor (torch.Tensor): the input data to be potentially padded.
 
         Returns:
-            Tuple[torch.Tensor, Optional[torch.Size]]: the padded tensor, where the original data is found in the center,
-            and the old size if padding was possible. If not possible or the shape is already fine,
-            the data is returned untouched and the second return value will be none.
+            tuple[torch.Tensor, torch.Size]: the padded tensor, where the original data is found in the center,
+            and the old size. If padding not possible or the shape is already fine,
+            the data is returned untouched with it's old shape, which is unchanged.
         """
-        if not self.settings.autopad_enabled:
-            return data_tensor, None
-
         old_shape = data_tensor.shape[-len(self.input_shape) :]
+
+        if not self.settings.autopad_enabled:
+            return data_tensor, old_shape
+
         valid_shape, new_shape = self.validate_input_shape(
             data_tensor.shape[-len(self.input_shape) :]
         )
@@ -159,11 +160,13 @@ class AutoPaddingModel(ABC):
             return pad_batch(
                 batch=data_tensor, new_shape=new_shape, pad_value=0
             ), old_shape
-        return data_tensor, None
+        return data_tensor, old_shape
 
     def _maybe_unpadding(
-        self, data_tensor: torch.Tensor, old_shape: torch.Size
-    ) -> torch.Tensor | ValueError:
+        self,
+        data_tensor: torch.Tensor,
+        old_shape: torch.Size,
+    ) -> torch.Tensor:
         """Potentially removes the padding previously added to the given tensor. This action
            is only carried out if autopadding was enabled via the settings.
 
@@ -173,8 +176,8 @@ class AutoPaddingModel(ABC):
             [W,H] or [W,H,D] for 2D and 3D data respectively. old_shape is returned by self._maybe_padding.
 
         Returns:
-            torch.Tensor: The data tensor with the padding removed, if possible.
+            torch.Tensor: The data tensor with the padding removed, or untouched if already at the right shape.
         """
-        if self.settings.autopad_enabled and old_shape is not None:
+        if self.settings.autopad_enabled:
             return undo_padding(data_tensor, old_shape=old_shape)
         return data_tensor

--- a/mfai/torch/models/base.py
+++ b/mfai/torch/models/base.py
@@ -4,11 +4,13 @@ Interface contract for our models.
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, Union
 from torch import Size
+from torch import nn
 import torch
 
 from mfai.torch.padding import pad_batch, undo_padding
+
 
 class ModelType(Enum):
     """
@@ -29,6 +31,10 @@ class ModelABC(ABC):
     # to be included in the registry of available models.
     register: bool = False
 
+    in_channels: int
+    out_channels: int
+    input_shape: tuple[int, ...]
+
     @property
     @abstractmethod
     def onnx_supported(self) -> bool:
@@ -38,7 +44,7 @@ class ModelABC(ABC):
 
     @property
     @abstractmethod
-    def settings_kls(self):
+    def settings_kls(self) -> Any:
         """
         Returns the settings class for this model.
         """
@@ -87,7 +93,7 @@ class ModelABC(ABC):
     def features_second(self) -> bool:
         return not self.features_last
 
-    def check_required_attributes(self):
+    def check_required_attributes(self) -> None:
         # we check that the model has defined the following attributes.
         # this must be called at the end of the __init__ of each subclass.
         required_attrs = ["in_channels", "out_channels", "input_shape"]
@@ -96,57 +102,79 @@ class ModelABC(ABC):
                 raise AttributeError(f"Missing required attribute : {attr}")
 
 
+# Drived class to specify type hinting
+class BaseModel(ModelABC, nn.Module):
+    pass
+
+
 class AutoPaddingModel(ABC):
+    input_shape: tuple[int, ...]
+
+    @property
     @abstractmethod
-    def validate_input_shape(self, input_shape: Size) -> Tuple[bool | Size]:
-        """ Given an input shape, verifies whether the inputs fit with the 
-            calling model's specifications. 
+    def settings(self) -> Any:
+        """
+        Returns the settings instance used to configure for this model.
+        """
+
+    @abstractmethod
+    def validate_input_shape(self, input_shape: Size) -> Tuple[bool, Size]:
+        """Given an input shape, verifies whether the inputs fit with the
+            calling model's specifications.
 
         Args:
-            input_shape (Size): The shape of the input data, excluding any batch dimension and channel dimension.  
+            input_shape (Size): The shape of the input data, excluding any batch dimension and channel dimension.
                                 For example, for a batch of 2D tensors of shape [B,C,W,H], [W,H] should be passed.
-                                For 3D data instead of shape [B,C,W,H,D], instead, [W,H,D] should be passed. 
+                                For 3D data instead of shape [B,C,W,H,D], instead, [W,H,D] should be passed.
 
         Returns:
-            Tuple[bool, Size]: Returns a tuple where the first element is a boolean signaling whether the given input shape 
-                                already fits the model's requirements. If that value is False, the second element contains the closest 
+            Tuple[bool, Size]: Returns a tuple where the first element is a boolean signaling whether the given input shape
+                                already fits the model's requirements. If that value is False, the second element contains the closest
                                 shape that fits the model, otherwise it will be None.
         """
-        
-    def _maybe_padding(self, data_tensor: torch.Tensor)-> Tuple[torch.Tensor, Optional[torch.Size]]:
-        """ Performs an optional padding to ensure that the data tensor can be fed 
-            to the underlying model. Padding will happen if if 
+
+    def _maybe_padding(
+        self, data_tensor: torch.Tensor
+    ) -> Tuple[Union[torch.Tensor, ValueError], Optional[torch.Size]]:
+        """Performs an optional padding to ensure that the data tensor can be fed
+            to the underlying model. Padding will happen if if
             autopadding was enabled via the settings.
 
         Args:
-            data_tensor (torch.Tensor): the input data to be potentially padded. 
+            data_tensor (torch.Tensor): the input data to be potentially padded.
 
         Returns:
-            Tuple[torch.Tensor, Optional[torch.Size]]: the padded tensor, where the original data is found in the center, 
-            and the old size if padding was possible. If not possible or the shape is already fine, 
-            the data is returned untouched and the second return value will be none. 
+            Tuple[torch.Tensor, Optional[torch.Size]]: the padded tensor, where the original data is found in the center,
+            and the old size if padding was possible. If not possible or the shape is already fine,
+            the data is returned untouched and the second return value will be none.
         """
-        if not self._settings.autopad_enabled:
+        if not self.settings.autopad_enabled:
             return data_tensor, None
-        
-        old_shape = data_tensor.shape[-len(self.input_shape):]
-        valid_shape, new_shape = self.validate_input_shape(data_tensor.shape[-len(self.input_shape):])
+
+        old_shape = data_tensor.shape[-len(self.input_shape) :]
+        valid_shape, new_shape = self.validate_input_shape(
+            data_tensor.shape[-len(self.input_shape) :]
+        )
         if not valid_shape:
-            return pad_batch(batch=data_tensor, new_shape=new_shape, pad_value=0), old_shape
+            return pad_batch(
+                batch=data_tensor, new_shape=new_shape, pad_value=0
+            ), old_shape
         return data_tensor, None
-    
-    def _maybe_unpadding(self, data_tensor: torch.Tensor, old_shape: torch.Size)-> torch.Tensor:
-        """Potentially removes the padding previously added to the given tensor. This action 
+
+    def _maybe_unpadding(
+        self, data_tensor: torch.Tensor, old_shape: torch.Size
+    ) -> torch.Tensor | ValueError:
+        """Potentially removes the padding previously added to the given tensor. This action
            is only carried out if autopadding was enabled via the settings.
 
         Args:
-            data_tensor (torch.Tensor): The data tensor from which padding is to be removed. 
-            old_shape (torch.Size): The previous shape of the data tensor. It can either be 
+            data_tensor (torch.Tensor): The data tensor from which padding is to be removed.
+            old_shape (torch.Size): The previous shape of the data tensor. It can either be
             [W,H] or [W,H,D] for 2D and 3D data respectively. old_shape is returned by self._maybe_padding.
 
         Returns:
             torch.Tensor: The data tensor with the padding removed, if possible.
         """
-        if self._settings.autopad_enabled and old_shape is not None:
+        if self.settings.autopad_enabled and old_shape is not None:
             return undo_padding(data_tensor, old_shape=old_shape)
         return data_tensor

--- a/mfai/torch/models/clip.py
+++ b/mfai/torch/models/clip.py
@@ -1,6 +1,7 @@
 """
 Implementation of CLIP (Contrastive Langage-Image Pre-training) model. Based on the original https://arxiv.org/abs/2103.00020
 """
+
 from dataclasses import dataclass
 from typing import Tuple, Union
 

--- a/mfai/torch/models/deeplabv3.py
+++ b/mfai/torch/models/deeplabv3.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 from dataclasses_json import dataclass_json
 from torch.nn import functional as F
 
-from .base import ModelABC, ModelType
+from .base import BaseModel, ModelType
 from .resnet import get_resnet_encoder
 
 
@@ -261,7 +261,7 @@ class DeepLabV3Settings:
     aux_params: Optional[dict] = None
 
 
-class DeepLabV3(ModelABC, torch.nn.Module):
+class DeepLabV3(BaseModel):
     """DeepLabV3_ implementation from "Rethinking Atrous Convolution for Semantic Image Segmentation"
 
     Args:

--- a/mfai/torch/models/half_unet.py
+++ b/mfai/torch/models/half_unet.py
@@ -78,8 +78,8 @@ class HalfUNet(BaseModel, AutoPaddingModel):
         out_channels: int,
         input_shape: tuple[int, ...],
         settings: HalfUNetSettings = HalfUNetSettings(),
-        *args: dict[str, Any],
-        **kwargs: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
 

--- a/mfai/torch/models/half_unet.py
+++ b/mfai/torch/models/half_unet.py
@@ -8,7 +8,7 @@ import torch
 from dataclasses_json import dataclass_json
 from torch import nn
 
-from mfai.torch.models.base import AutoPaddingModel, ModelABC, ModelType
+from mfai.torch.models.base import AutoPaddingModel, BaseModel, ModelType
 from mfai.torch.models.utils import AbsolutePosEmdebding
 
 
@@ -63,7 +63,7 @@ class GhostModule(nn.Module):
         return self.relu(x)
 
 
-class HalfUNet(ModelABC, AutoPaddingModel, nn.Module):
+class HalfUNet(BaseModel, AutoPaddingModel):
     settings_kls = HalfUNetSettings
     onnx_supported: bool = True
     supported_num_spatial_dims = (2,)

--- a/mfai/torch/models/half_unet.py
+++ b/mfai/torch/models/half_unet.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from functools import reduce
 from math import ceil
-from typing import Tuple, Union
+from typing import Any, Literal, Sequence
 
 import torch
 from dataclasses_json import dataclass_json
@@ -30,10 +30,10 @@ class GhostModule(nn.Module):
         in_channels: int = 64,
         out_channels: int = 64,
         bias: bool = False,
-        kernel_size=3,
-        padding="same",
-        dilation=1,
-    ):
+        kernel_size: tuple[int, int] = (3, 3),
+        padding: Literal["valid", "same"] | tuple[int, int] = "same",
+        dilation: int = 1,
+    ) -> None:
         super().__init__()
 
         self.conv = nn.Conv2d(
@@ -55,7 +55,7 @@ class GhostModule(nn.Module):
         self.bn = nn.BatchNorm2d(num_features=out_channels)
         self.relu = nn.ReLU(inplace=True)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.conv(x)
         x2 = self.sepconv(x)
         x = torch.cat([x, x2], dim=1)
@@ -69,35 +69,24 @@ class HalfUNet(BaseModel, AutoPaddingModel):
     supported_num_spatial_dims = (2,)
     num_spatial_dims: int = 2
     features_last: bool = False
-    model_type: int = ModelType.CONVOLUTIONAL
+    model_type: ModelType = ModelType.CONVOLUTIONAL
     register: bool = True
 
     def __init__(
         self,
         in_channels: int,
         out_channels: int,
-        input_shape: Union[None, Tuple[int, int]] = None,
+        input_shape: tuple[int, ...],
         settings: HalfUNetSettings = HalfUNetSettings(),
-        *args,
-        **kwargs,
-    ):
-        if settings.absolute_pos_embed and input_shape is None:
-            raise ValueError(
-                "You must provide a grid_shape to use absolute_pos_embed in HalfUnet"
-            )
-
+        *args: dict[str, Any],
+        **kwargs: dict[str, Any],
+    ) -> None:
         super().__init__(*args, **kwargs)
 
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.input_shape = input_shape
         self._settings = settings
-
-        if settings.absolute_pos_embed:
-            if input_shape is None:
-                raise ValueError(
-                    "You must provide an input_shape to use absolute_pos_embed in HalfUnet"
-                )
 
         self.encoder1 = self._block(
             in_channels,
@@ -120,10 +109,10 @@ class HalfUNet(BaseModel, AutoPaddingModel):
             use_ghost=settings.use_ghost,
             dilation=settings.dilation,
             absolute_pos_embed=settings.absolute_pos_embed,
-            grid_shape=[x // 2 for x in input_shape] if input_shape else None,
+            grid_shape=[x // 2 for x in input_shape],
         )
         self.up2 = nn.UpsamplingBilinear2d(scale_factor=2)
-        self.pool2 = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.pool2 = nn.MaxPool2d(kernel_size=(2, 2), stride=2)
 
         self.encoder3 = self._block(
             settings.num_filters,
@@ -133,11 +122,11 @@ class HalfUNet(BaseModel, AutoPaddingModel):
             use_ghost=settings.use_ghost,
             dilation=settings.dilation,
             absolute_pos_embed=settings.absolute_pos_embed,
-            grid_shape=[x // 4 for x in input_shape] if input_shape else None,
+            grid_shape=[x // 4 for x in input_shape],
         )
 
         self.up3 = nn.UpsamplingBilinear2d(scale_factor=4)
-        self.pool3 = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.pool3 = nn.MaxPool2d(kernel_size=(2, 2), stride=2)
 
         self.encoder4 = self._block(
             settings.num_filters,
@@ -147,7 +136,7 @@ class HalfUNet(BaseModel, AutoPaddingModel):
             use_ghost=settings.use_ghost,
             dilation=settings.dilation,
             absolute_pos_embed=settings.absolute_pos_embed,
-            grid_shape=[x // 8 for x in input_shape] if input_shape else None,
+            grid_shape=[x // 8 for x in input_shape],
         )
         self.up4 = nn.UpsamplingBilinear2d(scale_factor=8)
         self.pool4 = nn.MaxPool2d(kernel_size=2, stride=2)
@@ -160,7 +149,7 @@ class HalfUNet(BaseModel, AutoPaddingModel):
             use_ghost=settings.use_ghost,
             dilation=settings.dilation,
             absolute_pos_embed=settings.absolute_pos_embed,
-            grid_shape=[x // 16 for x in input_shape] if input_shape else None,
+            grid_shape=[x // 16 for x in input_shape],
         )
         self.up5 = nn.UpsamplingBilinear2d(scale_factor=16)
 
@@ -190,7 +179,7 @@ class HalfUNet(BaseModel, AutoPaddingModel):
     def settings(self) -> HalfUNetSettings:
         return self._settings
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x, old_shape = self._maybe_padding(data_tensor=x)
 
         enc1 = self.encoder1(x)
@@ -211,16 +200,16 @@ class HalfUNet(BaseModel, AutoPaddingModel):
 
     @staticmethod
     def _block(
-        in_channels,
-        features,
-        name,
-        bias=False,
+        nb_in_channels: int,
+        nb_features: int,
+        name: str,
+        grid_shape: Sequence[int],
+        bias: bool = False,
         use_ghost: bool = False,
         dilation: int = 1,
-        padding="same",
+        padding: Literal["valid", "same"] | tuple[int, int] = "same",
         absolute_pos_embed: bool = False,
-        grid_shape: Tuple[int, int] = None,
-    ):
+    ) -> nn.Sequential:
         if use_ghost:
             layers = nn.Sequential(
                 OrderedDict(
@@ -228,9 +217,9 @@ class HalfUNet(BaseModel, AutoPaddingModel):
                         (
                             name + "ghost1",
                             GhostModule(
-                                in_channels=in_channels,
-                                out_channels=features,
-                                kernel_size=3,
+                                in_channels=nb_in_channels,
+                                out_channels=nb_features,
+                                kernel_size=(3, 3),
                                 padding=padding,
                                 bias=bias,
                                 dilation=dilation,
@@ -239,9 +228,9 @@ class HalfUNet(BaseModel, AutoPaddingModel):
                         (
                             name + "ghost2",
                             GhostModule(
-                                in_channels=features,
-                                out_channels=features,
-                                kernel_size=3,
+                                in_channels=nb_features,
+                                out_channels=nb_features,
+                                kernel_size=(3, 3),
                                 padding=padding,
                                 bias=bias,
                                 dilation=dilation,
@@ -257,28 +246,28 @@ class HalfUNet(BaseModel, AutoPaddingModel):
                         (
                             name + "conv1",
                             nn.Conv2d(
-                                in_channels=in_channels,
-                                out_channels=features,
+                                in_channels=nb_in_channels,
+                                out_channels=nb_features,
                                 kernel_size=3,
                                 padding=padding,
                                 bias=bias,
                                 dilation=dilation,
                             ),
                         ),
-                        (name + "norm1", nn.BatchNorm2d(num_features=features)),
+                        (name + "norm1", nn.BatchNorm2d(num_features=nb_features)),
                         (name + "relu1", nn.ReLU(inplace=True)),
                         (
                             name + "conv2",
                             nn.Conv2d(
-                                in_channels=features,
-                                out_channels=features,
+                                in_channels=nb_features,
+                                out_channels=nb_features,
                                 kernel_size=3,
                                 padding=padding,
                                 bias=bias,
                                 dilation=dilation,
                             ),
                         ),
-                        (name + "norm2", nn.BatchNorm2d(num_features=features)),
+                        (name + "norm2", nn.BatchNorm2d(num_features=nb_features)),
                         (name + "relu2", nn.ReLU(inplace=True)),
                     ]
                 )
@@ -287,13 +276,13 @@ class HalfUNet(BaseModel, AutoPaddingModel):
             layers = nn.Sequential(
                 AbsolutePosEmdebding(
                     input_shape=(grid_shape[0], grid_shape[1]),
-                    num_features=in_channels,
+                    num_features=nb_in_channels,
                 ),
                 *layers,
             )
         return layers
 
-    def validate_input_shape(self, input_shape: torch.Size) -> Tuple[bool | torch.Size]:
+    def validate_input_shape(self, input_shape: torch.Size) -> tuple[bool, torch.Size]:
         number_pool_layers = sum(
             1 for layer in self.modules() if isinstance(layer, nn.MaxPool2d)
         )
@@ -303,7 +292,8 @@ class HalfUNet(BaseModel, AutoPaddingModel):
         # be divisible by 2^N
         d = 2**number_pool_layers
 
-        new_shape = [d * ceil(input_shape[i] / d) for i in range(len(input_shape))]
-        new_shape = torch.Size(new_shape)
+        new_shape = torch.Size(
+            [d * ceil(input_shape[i] / d) for i in range(len(input_shape))]
+        )
 
         return new_shape == input_shape, new_shape

--- a/mfai/torch/models/llms/__init__.py
+++ b/mfai/torch/models/llms/__init__.py
@@ -19,7 +19,7 @@ from mfai.torch.models.base import ModelType
 
 
 class LayerNorm(nn.Module):
-    def __init__(self, emb_dim: int):
+    def __init__(self, emb_dim: int) -> None:
         super().__init__()
         self.eps = 1e-5
         self.scale = nn.Parameter(torch.ones(emb_dim))
@@ -33,7 +33,7 @@ class LayerNorm(nn.Module):
 
 
 class GELU(nn.Module):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def forward(self, x: Tensor) -> Tensor:
@@ -51,7 +51,7 @@ class GELU(nn.Module):
 
 
 class FeedForward(nn.Module):
-    def __init__(self, emb_dim: int):
+    def __init__(self, emb_dim: int) -> None:
         super().__init__()
         self.layers = nn.Sequential(
             nn.Linear(emb_dim, 4 * emb_dim),
@@ -76,7 +76,7 @@ class MultiHeadAttentionPySDPA(nn.Module):
         context_length: int,
         dropout: float = 0.0,
         qkv_bias: bool = False,
-    ):
+    ) -> None:
         super().__init__()
 
         if d_out % num_heads != 0:
@@ -148,7 +148,7 @@ class TransformerBlock(nn.Module):
 
     """
 
-    def __init__(self, settings: GPT2Settings):
+    def __init__(self, settings: GPT2Settings) -> None:
         super().__init__()
         self.att = MultiHeadAttentionPySDPA(
             d_in=settings.emb_dim,
@@ -191,7 +191,7 @@ class GPT2(nn.Module):
     settings_kls = GPT2Settings
     model_type = ModelType.LLM
 
-    def __init__(self, settings: GPT2Settings, vocab_size: int = 50257):
+    def __init__(self, settings: GPT2Settings, vocab_size: int = 50257) -> None:
         super().__init__()
         self.context_length = settings.context_length
         self.emb_dim = settings.emb_dim
@@ -258,7 +258,7 @@ class GPT2(nn.Module):
 
 
 class RMSNorm(nn.Module):
-    def __init__(self, emb_dim: int, eps: float = 1e-5):
+    def __init__(self, emb_dim: int, eps: float = 1e-5) -> None:
         super().__init__()
         self.eps = eps
         self.emb_dim = emb_dim
@@ -271,7 +271,7 @@ class RMSNorm(nn.Module):
 
 
 class SiLU(nn.Module):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def forward(self, x: Tensor) -> Tensor:
@@ -279,7 +279,9 @@ class SiLU(nn.Module):
 
 
 class FeedForwardLlama2(nn.Module):
-    def __init__(self, emb_dim: int, hidden_dim: int, dtype: torch.dtype = None):
+    def __init__(
+        self, emb_dim: int, hidden_dim: int, dtype: torch.dtype = None
+    ) -> None:
         super().__init__()
         self.fc1 = nn.Linear(emb_dim, hidden_dim, dtype=dtype, bias=False)
         self.fc2 = nn.Linear(emb_dim, hidden_dim, dtype=dtype, bias=False)
@@ -344,6 +346,9 @@ class MultiHeadAttentionPySDPALlama2(nn.Module):
     Mutli Head Attention using Pytorch's scaled_dot_product_attention
     """
 
+    cos: torch.Tensor
+    sin: torch.Tensor
+
     def __init__(
         self,
         d_in: int,
@@ -351,7 +356,7 @@ class MultiHeadAttentionPySDPALlama2(nn.Module):
         num_heads: int,
         context_length: int,
         dtype: torch.dtype = None,
-    ):
+    ) -> None:
         super().__init__()
 
         assert d_out % num_heads == 0, "embed_dim is indivisible by num_heads"
@@ -427,7 +432,7 @@ class TransformerBlockLlama2(nn.Module):
 
     """
 
-    def __init__(self, settings: Llama2Settings):
+    def __init__(self, settings: Llama2Settings) -> None:
         super().__init__()
         self.att = MultiHeadAttentionPySDPALlama2(
             d_in=settings.emb_dim,
@@ -465,7 +470,7 @@ class Llama2(nn.Module):
     settings_kls = Llama2Settings
     model_type = ModelType.LLM
 
-    def __init__(self, settings: Llama2Settings, vocab_size: int = 32000):
+    def __init__(self, settings: Llama2Settings, vocab_size: int = 32000) -> None:
         super().__init__()
         self.emb_dim = settings.emb_dim
         self.tok_emb = nn.Embedding(vocab_size, self.emb_dim)

--- a/mfai/torch/models/llms/multimodal.py
+++ b/mfai/torch/models/llms/multimodal.py
@@ -4,9 +4,11 @@ from torch import Tensor
 from dataclasses import dataclass, asdict
 from dataclasses_json import dataclass_json
 import math
+import einops
 from mfai.torch.models.llms import GPT2, Llama2
 from mfai.torch.models.base import ModelType
 from mfai.torch.namedtensor import NamedTensor
+from mfai.torch.models.resnet import ResNet50
 from typing import Literal
 
 
@@ -37,6 +39,10 @@ class MultiModalLMSettings:
 
     # Inject vision tokens at each stage ?
     inject_vision_each_stage: bool = False
+
+    # choice of vision encoder
+    # "resnet50", "linear"
+    vision_encoder: Literal["resnet50", "linear"] = "linear"
 
 
 class MultiModalLM(nn.Module):
@@ -99,22 +105,33 @@ class MultiModalLM(nn.Module):
         # downsampled spatial dims
         self.downsampler = nn.MaxPool2d(settings.downsampling_rate)
 
-        # One linear projection per feature/weather field
-        self.linear_vis_projs = nn.ModuleList(
-            [
-                nn.Linear(spatial_dims, settings.emb_dim)
-                for _ in range(settings.vision_input_shape[3])
-            ]
-        )
-
-        self.layer_norm_vis = settings.layer_norm_vis
-        if settings.layer_norm_vis:
-            # One Layer Norm per feature
-            self.vis_layer_norms = nn.ModuleList(
+        if self.settings.vision_encoder == "linear":
+            # One linear projection per feature/weather field
+            self.linear_vis_projs = nn.ModuleList(
                 [
-                    torch.nn.LayerNorm(spatial_dims)
+                    nn.Linear(spatial_dims, settings.emb_dim)
                     for _ in range(settings.vision_input_shape[3])
                 ]
+            )
+
+            self.layer_norm_vis = settings.layer_norm_vis
+            if settings.layer_norm_vis:
+                # One Layer Norm per feature
+                self.vis_layer_norms = nn.ModuleList(
+                    [
+                        torch.nn.LayerNorm(spatial_dims)
+                        for _ in range(settings.vision_input_shape[3])
+                    ]
+                )
+        elif self.settings.vision_encoder == "resnet50":
+            self.resnet50 = ResNet50(
+                num_channels=settings.vision_input_shape[3]
+                * settings.vision_input_shape[2],
+                num_classes=settings.emb_dim,
+            )
+        else:
+            raise ValueError(
+                f"Unknown vision encoder: {self.settings.vision_encoder}. Use 'linear' or 'resnet50'."
             )
 
     @property
@@ -138,26 +155,49 @@ class MultiModalLM(nn.Module):
     def forward(self, text_tokens: Tensor, vision_input: NamedTensor) -> Tensor:
         # Linear projection of weather input data
         vis_timesteps_embeds = []
+        if self.settings.vision_encoder == "linear":
+            for timestep_nt in vision_input.iter_dim("timestep", bare_tensor=False):
+                timestep_embed = []
+                # batch, lat, lon, features
+                # rearrange to batch, features, lat, lon
+                timestep_nt.rearrange_(
+                    "batch lat lon features -> batch features lat lon"
+                )
 
-        for timestep_nt in vision_input.iter_dim("timestep", bare_tensor=False):
-            timestep_embed = []
-            # batch, lat, lon, features
-            # rearrange to batch, features, lat, lon
-            timestep_nt.rearrange_("batch lat lon features -> batch features lat lon")
+                for i in range(timestep_nt.dim_size("features")):
+                    timestep_tensor = timestep_nt.select_dim("features", i)
+                    timestep_tensor = self.downsampler(timestep_tensor)
+                    timestep_tensor = timestep_tensor.flatten(1, 2)
+                    if self.layer_norm_vis:
+                        timestep_tensor = self.vis_layer_norms[i](timestep_tensor)
+                    timestep_embed.append(self.linear_vis_projs[i](timestep_tensor))
 
-            for i in range(timestep_nt.dim_size("features")):
-                timestep_tensor = timestep_nt.select_dim("features", i)
-                timestep_tensor = self.downsampler(timestep_tensor)
-                timestep_tensor = timestep_tensor.flatten(1, 2)
-                if self.layer_norm_vis:
-                    timestep_tensor = self.vis_layer_norms[i](timestep_tensor)
-                timestep_embed.append(self.linear_vis_projs[i](timestep_tensor))
+                timestep_embed_tensor = torch.stack(timestep_embed, dim=1)
+                vis_timesteps_embeds.append(timestep_embed_tensor)
+            vis_embeds = torch.cat(vis_timesteps_embeds, dim=1)
 
-            timestep_embed_tensor = torch.stack(timestep_embed, dim=1)
-            vis_timesteps_embeds.append(timestep_embed_tensor)
+        elif self.settings.vision_encoder == "resnet50":
+            new_tensor = einops.rearrange(
+                vision_input.tensor,
+                "batch lat lon timestep features -> batch (timestep features) lat lon",
+            )
+
+            # Resnet50 encoder
+            vis_embeds = self.resnet50(new_tensor)
+
+            # Normalize the output
+            vis_embeds = vis_embeds / vis_embeds.norm(dim=1, keepdim=True)
+
+            vis_embeds = vis_embeds.unsqueeze(1)
+
+        else:
+            raise ValueError(
+                f"Unknown vision encoder: {self.settings.vision_encoder}. Use 'linear' or 'resnet50'."
+            )
+
 
         text_embeds = self.backend.tok_emb(text_tokens)
-        vis_embeds = torch.cat(vis_timesteps_embeds, dim=1)
+
         vis_txt_embeds = torch.cat([vis_embeds, text_embeds], dim=1)
         if vis_txt_embeds.shape[1] > self.context_length:
             print(

--- a/mfai/torch/models/llms/multimodal.py
+++ b/mfai/torch/models/llms/multimodal.py
@@ -7,6 +7,7 @@ import math
 from mfai.torch.models.llms import GPT2, Llama2
 from mfai.torch.models.base import ModelType
 from mfai.torch.namedtensor import NamedTensor
+from typing import Literal
 
 
 @dataclass_json
@@ -45,7 +46,7 @@ class MultiModalLM(nn.Module):
     """
 
     settings_kls = MultiModalLMSettings
-    model_type: ModelType.MULTIMODAL_LLM
+    model_type: Literal[ModelType.MULTIMODAL_LLM]
 
     def __init__(
         self,
@@ -58,6 +59,7 @@ class MultiModalLM(nn.Module):
         # Init the backend model
         # Here we only pass the settings that are relevant to the backend model
         # by iterating over the fields of the settings object and filtering out
+        self.backend: GPT2 | Llama2
         if settings.backend == "gpt2":
             self.backend = GPT2(
                 GPT2.settings_kls(
@@ -116,17 +118,17 @@ class MultiModalLM(nn.Module):
             )
 
     @property
-    def context_length(self):
+    def context_length(self) -> int:
         return self.backend.context_length
 
-    def freeze_llm(self):
+    def freeze_llm(self) -> None:
         """
         Freeze the LLM layers (not the vision layers)
         """
         for param in self.backend.parameters():
             param.requires_grad = False
 
-    def unfreeze_llm(self):
+    def unfreeze_llm(self) -> None:
         """
         Unfreeze the LLM layers
         """
@@ -151,8 +153,8 @@ class MultiModalLM(nn.Module):
                     timestep_tensor = self.vis_layer_norms[i](timestep_tensor)
                 timestep_embed.append(self.linear_vis_projs[i](timestep_tensor))
 
-            timestep_embed = torch.stack(timestep_embed, dim=1)
-            vis_timesteps_embeds.append(timestep_embed)
+            timestep_embed_tensor = torch.stack(timestep_embed, dim=1)
+            vis_timesteps_embeds.append(timestep_embed_tensor)
 
         text_embeds = self.backend.tok_emb(text_tokens)
         vis_embeds = torch.cat(vis_timesteps_embeds, dim=1)
@@ -165,7 +167,9 @@ class MultiModalLM(nn.Module):
             vis_txt_embeds = vis_txt_embeds[:, -self.context_length :]
         embeds_idx = torch.arange(vis_txt_embeds.shape[1], device=text_tokens.device)
 
-        if hasattr(self.backend, "pos_emb"):
+        if hasattr(self.backend, "pos_emb") and isinstance(
+            self.backend.pos_emb, nn.Embedding
+        ):
             pos_embeds = self.backend.pos_emb(embeds_idx)
             x = vis_txt_embeds + pos_embeds.unsqueeze(0)
         else:

--- a/mfai/torch/models/nlam/__init__.py
+++ b/mfai/torch/models/nlam/__init__.py
@@ -9,7 +9,7 @@ from typing import Tuple
 import torch
 import torch_geometric as pyg
 from dataclasses_json import dataclass_json
-from mfai.torch.models.base import ModelABC, ModelType
+from mfai.torch.models.base import BaseModel, ModelType
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import offload_wrapper
 
@@ -178,7 +178,7 @@ class GraphLamSettings:
         return f"ModelCOnfig : {self.hidden_dims}x{self.hidden_layers}x{self.processor_layers}"
 
 
-class BaseGraphModel(ModelABC, nn.Module):
+class BaseGraphModel(BaseModel):
     """
     Base (abstract) class for graph-based models building on
     the encode-process-decode idea.

--- a/mfai/torch/models/resnet.py
+++ b/mfai/torch/models/resnet.py
@@ -65,10 +65,10 @@ class EncoderMixin:
         self._output_stride = output_stride
 
         stages = self.get_stages()
-        for stage_indx, dilation_rate in zip(stage_list, dilation_list):
+        for stage_indx, dilation in zip(stage_list, dilation_list):
             utils.replace_strides_with_dilation(
                 module=stages[stage_indx],
-                dilation_rate=dilation_rate,
+                dilation=dilation,
             )
 
 

--- a/mfai/torch/models/resnet.py
+++ b/mfai/torch/models/resnet.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Tuple, Union
+from typing import Any, Literal, Union
 
 import torch
 import torch.nn as nn
@@ -14,21 +14,49 @@ from mfai.torch.models import utils
 ##########################################################################################################
 
 
-class EncoderMixin:
-    """Add encoder functionality such as:
+class ResNetEncoder(ResNet):
+    """Resnet with encoder functionality such as:
     - output channels specification of feature tensors (produced by encoder)
     - patching first convolution for arbitrary input channels
     """
+    def __init__(self, out_channels: tuple[int, ...], depth: int = 5, **kwargs: dict[str, Any]):
+        super().__init__(**kwargs)
+        self._depth = depth
+        self._out_channels = out_channels
+        self._in_channels = 3
 
-    _output_stride = 32
+        del self.fc
+        del self.avgpool
 
+        self.stages: list[nn.Module] = [
+            nn.Identity(),
+            nn.Sequential(self.conv1, self.bn1, self.relu),
+            nn.Sequential(self.maxpool, self.layer1),
+            self.layer2,
+            self.layer3,
+            self.layer4,
+        ]
+
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+        features = []
+        for i in range(self._depth + 1):
+            x = self.stages[i](x)
+            features.append(x)
+
+        return features
+
+    def load_state_dict(self, state_dict: dict[str, Any], **kwargs: dict[str, Any]) -> None:
+        state_dict.pop("fc.bias", None)
+        state_dict.pop("fc.weight", None)
+        super().load_state_dict(state_dict, **kwargs)
+    
     @property
-    def out_channels(self) -> int:
+    def out_channels(self) -> tuple[int, ...]:
         """Return channels dimensions for each tensor of forward output of encoder"""
         return self._out_channels[: self._depth + 1]
 
     @property
-    def output_stride(self):
+    def output_stride(self) -> int:
         return min(self._output_stride, 2**self._depth)
 
     def set_in_channels(self, in_channels: int, pretrained: bool = True) -> None:
@@ -43,10 +71,6 @@ class EncoderMixin:
         utils.patch_first_conv(
             model=self, new_in_channels=in_channels, pretrained=pretrained
         )
-
-    def get_stages(self):
-        """Override it in your implementation"""
-        raise NotImplementedError
 
     def make_dilated(self, output_stride: int) -> None:
         if output_stride == 16:
@@ -64,51 +88,14 @@ class EncoderMixin:
 
         self._output_stride = output_stride
 
-        stages = self.get_stages()
         for stage_indx, dilation in zip(stage_list, dilation_list):
             utils.replace_strides_with_dilation(
-                module=stages[stage_indx],
+                module=self.stages[stage_indx],
                 dilation=dilation,
             )
 
 
-class ResNetEncoder(ResNet, EncoderMixin):
-    def __init__(self, out_channels: int, depth: int = 5, **kwargs):
-        super().__init__(**kwargs)
-        self._depth = depth
-        self._out_channels = out_channels
-        self._in_channels = 3
-
-        del self.fc
-        del self.avgpool
-
-    def get_stages(self) -> List[nn.Module]:
-        return [
-            nn.Identity(),
-            nn.Sequential(self.conv1, self.bn1, self.relu),
-            nn.Sequential(self.maxpool, self.layer1),
-            self.layer2,
-            self.layer3,
-            self.layer4,
-        ]
-
-    def forward(self, x) -> List[torch.Tensor]:
-        stages = self.get_stages()
-
-        features = []
-        for i in range(self._depth + 1):
-            x = stages[i](x)
-            features.append(x)
-
-        return features
-
-    def load_state_dict(self, state_dict, **kwargs) -> None:
-        state_dict.pop("fc.bias", None)
-        state_dict.pop("fc.weight", None)
-        super().load_state_dict(state_dict, **kwargs)
-
-
-ENCODERS_MAP = {
+ENCODERS_MAP: dict[Literal['resnet18', 'resnet34', 'resnet50'], dict[str, Any]] = {
     "resnet18": {
         "encoder": ResNetEncoder,
         "pretrained_url": "https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnet18-d92f0530.pth",  # noqa
@@ -140,17 +127,17 @@ ENCODERS_MAP = {
 
 
 def get_resnet_encoder(
-    name: str,
+    name: Literal['resnet18', 'resnet34', 'resnet50'],
     in_channels: int = 3,
     depth: int = 5,
     weights: bool = True,
     output_stride: int = 32,
-):
+) -> ResNetEncoder:
     """
     Return an encoder with pretrained weights or not.
     """
     try:
-        Encoder = ENCODERS_MAP[name]["encoder"]
+        Encoder: type[ResNetEncoder] = ENCODERS_MAP[name]["encoder"]
     except KeyError:
         raise KeyError(
             "Wrong encoder name `{}`, supported ENCODERS_MAP: {}".format(
@@ -201,7 +188,7 @@ class ResNet50(torch.nn.Module):
         self,
         num_channels: int = 3,
         num_classes: int = 1000,
-        input_shape: Union[None, Tuple[int, int]] = None,
+        input_shape: Union[None, tuple[int, int]] = None,
         settings: ResNet50Settings = ResNet50Settings(),
     ):
         super().__init__()

--- a/mfai/torch/models/segformer.py
+++ b/mfai/torch/models/segformer.py
@@ -5,7 +5,7 @@ SegFormer adapted from https://github.com/lucidrains/segformer-pytorch
 from dataclasses import dataclass
 from functools import partial
 from math import sqrt
-from typing import Tuple
+from typing import Any, Callable, Literal, Sequence
 
 import torch
 from dataclasses_json import dataclass_json
@@ -15,21 +15,21 @@ from torch import einsum, nn
 from .base import BaseModel, ModelType
 
 
-def exists(val):
+def exists(val: Any | None) -> bool:
     return val is not None
 
 
-def cast_tuple(val, depth):
+def cast_tuple(val: Any, depth: int) -> tuple[Any, ...]:
     return val if isinstance(val, tuple) else (val,) * depth
 
 
 @dataclass_json
 @dataclass(slots=True)
 class SegformerSettings:
-    dims: Tuple[int, ...] = (32, 64, 160, 256)
-    heads: Tuple[int, ...] = (1, 2, 5, 8)
-    ff_expansion: Tuple[int, ...] = (8, 8, 4, 4)
-    reduction_ratio: Tuple[int, ...] = (8, 4, 2, 1)
+    dims: tuple[int, ...] = (32, 64, 160, 256)
+    heads: tuple[int, ...] = (1, 2, 5, 8)
+    ff_expansion: tuple[int, ...] = (8, 8, 4, 4)
+    kernel_and_stride: tuple[int, ...] = (8, 4, 2, 1)
     num_layers: int = 2
     decoder_dim: int = 256
 
@@ -39,65 +39,86 @@ class SegformerSettings:
 
 
 class DsConv2d(nn.Module):
-    def __init__(self, dim_in, dim_out, kernel_size, padding, stride=1, bias=True):
+    def __init__(
+        self,
+        nb_in_channels: int,
+        nb_out_channels: int,
+        kernel_size: tuple[int, int],
+        padding: tuple[int, int] | Literal["valid", "same"],
+        stride: int = 1,
+        bias: bool = True,
+    ) -> None:
         super().__init__()
         self.net = nn.Sequential(
             nn.Conv2d(
-                dim_in,
-                dim_in,
+                in_channels=nb_in_channels,
+                out_channels=nb_in_channels,
                 kernel_size=kernel_size,
                 padding=padding,
-                groups=dim_in,
+                groups=nb_in_channels,
                 stride=stride,
                 bias=bias,
             ),
-            nn.Conv2d(dim_in, dim_out, kernel_size=1, bias=bias),
+            nn.Conv2d(nb_in_channels, nb_out_channels, kernel_size=1, bias=bias),
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.net(x)
 
 
 class LayerNorm(nn.Module):
-    def __init__(self, dim, eps=1e-5):
+    def __init__(self, dim: int, eps: float = 1e-5) -> None:
         super().__init__()
         self.eps = eps
         self.g = nn.Parameter(torch.ones(1, dim, 1, 1))
         self.b = nn.Parameter(torch.zeros(1, dim, 1, 1))
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         std = torch.var(x, dim=1, unbiased=False, keepdim=True).sqrt()
         mean = torch.mean(x, dim=1, keepdim=True)
         return (x - mean) / (std + self.eps) * self.g + self.b
 
 
 class PreNorm(nn.Module):
-    def __init__(self, dim, fn):
+    def __init__(self, dim: int, fn: Callable):
         super().__init__()
         self.fn = fn
         self.norm = LayerNorm(dim)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.fn(self.norm(x))
 
 
 class EfficientSelfAttention(nn.Module):
-    def __init__(self, *, dim, heads, reduction_ratio):
+    def __init__(
+        self,
+        *,
+        dim: int,
+        heads: int,
+        kernel_and_stride: int | tuple[int, int],
+    ) -> None:
         super().__init__()
         self.scale = (dim // heads) ** -0.5
         self.heads = heads
 
         self.to_q = nn.Conv2d(dim, dim, 1, bias=False)
         self.to_kv = nn.Conv2d(
-            dim, dim * 2, reduction_ratio, stride=reduction_ratio, bias=False
+            in_channels=dim,
+            out_channels=dim * 2,
+            kernel_size=kernel_and_stride,
+            stride=kernel_and_stride,
+            bias=False,
         )
         self.to_out = nn.Conv2d(dim, dim, 1, bias=False)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         h, w = x.shape[-2:]
         heads = self.heads
 
-        q, k, v = (self.to_q(x), *self.to_kv(x).chunk(2, dim=1))
+        q: torch.Tensor = self.to_q(x)
+        k: torch.Tensor
+        v: torch.Tensor
+        k, v = self.to_kv(x).chunk(2, dim=1)
         q, k, v = map(
             lambda t: rearrange(t, "b (h c) x y -> (b h) (x y) c", h=heads), (q, k, v)
         )
@@ -111,28 +132,35 @@ class EfficientSelfAttention(nn.Module):
 
 
 class MixFeedForward(nn.Module):
-    def __init__(self, *, dim, expansion_factor):
+    def __init__(self, *, dim: int, expansion_factor: int) -> None:
         super().__init__()
         hidden_dim = dim * expansion_factor
         self.net = nn.Sequential(
             nn.Conv2d(dim, hidden_dim, 1),
-            DsConv2d(hidden_dim, hidden_dim, 3, padding=1),
+            DsConv2d(hidden_dim, hidden_dim, (3, 3), padding=(1, 1)),
             nn.GELU(),
             nn.Conv2d(hidden_dim, dim, 1),
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.net(x)
 
 
 class MiT(nn.Module):
     def __init__(
-        self, *, channels, dims, heads, ff_expansion, reduction_ratio, num_layers
-    ):
+        self,
+        *,
+        channels: int,
+        dims: Sequence[int],
+        heads: Sequence[int],
+        ff_expansions: Sequence[int],
+        kernel_and_strides: Sequence[int],
+        num_layers: Sequence[int],
+    ) -> None:
         super().__init__()
         stage_kernel_stride_pad = ((7, 4, 3), (3, 2, 1), (3, 2, 1), (3, 2, 1))
 
-        dims = (channels, *dims)
+        dims = [channels, *dims]
         dim_pairs = list(zip(dims[:-1], dims[1:]))
 
         self.stages = nn.ModuleList([])
@@ -140,24 +168,24 @@ class MiT(nn.Module):
         for (
             (dim_in, dim_out),
             (kernel, stride, padding),
-            num_layers,
+            num_layer,
             ff_expansion,
-            heads,
-            reduction_ratio,
+            head,
+            kernel_and_stride,
         ) in zip(
             dim_pairs,
             stage_kernel_stride_pad,
             num_layers,
-            ff_expansion,
+            ff_expansions,
             heads,
-            reduction_ratio,
+            kernel_and_strides,
         ):
             get_overlap_patches = nn.Unfold(kernel, stride=stride, padding=padding)
             overlap_patch_embed = nn.Conv2d(dim_in * kernel**2, dim_out, 1)
 
             layers = nn.ModuleList([])
 
-            for _ in range(num_layers):
+            for _ in range(num_layer):
                 layers.append(
                     nn.ModuleList(
                         [
@@ -165,8 +193,8 @@ class MiT(nn.Module):
                                 dim_out,
                                 EfficientSelfAttention(
                                     dim=dim_out,
-                                    heads=heads,
-                                    reduction_ratio=reduction_ratio,
+                                    heads=head,
+                                    kernel_and_stride=kernel_and_stride,
                                 ),
                             ),
                             PreNorm(
@@ -183,7 +211,9 @@ class MiT(nn.Module):
                 nn.ModuleList([get_overlap_patches, overlap_patch_embed, layers])
             )
 
-    def forward(self, x, return_layer_outputs=False):
+    def forward(
+        self, x: torch.Tensor, return_layer_outputs: bool = False
+    ) -> torch.Tensor | list[torch.Tensor]:
         h, w = x.shape[-2:]
 
         layer_outputs = []
@@ -226,11 +256,11 @@ class Segformer(BaseModel):
         self,
         in_channels: int,
         out_channels: int,
-        input_shape: Tuple[int, int],
+        input_shape: tuple[int, int],
         settings: SegformerSettings = SegformerSettings(),
-        *args,
-        **kwargs,
-    ):
+        *args: dict[str, Any],
+        **kwargs: dict[str, Any],
+    ) -> None:
         super().__init__(*args, **kwargs)
 
         self.in_channels = in_channels
@@ -238,20 +268,25 @@ class Segformer(BaseModel):
         self.input_shape = input_shape
         self._settings = settings
 
-        dims, heads, ff_expansion, reduction_ratio, num_layers = map(
+        dims: tuple[int]
+        heads: tuple[int]
+        ff_expansion: tuple[int]
+        kernel_and_stride: tuple[int]
+        num_layers: tuple[int]
+        dims, heads, ff_expansion, kernel_and_stride, num_layers = map(
             partial(cast_tuple, depth=4),
             (
                 settings.dims,
                 settings.heads,
                 settings.ff_expansion,
-                settings.reduction_ratio,
+                settings.kernel_and_stride,
                 settings.num_layers,
             ),
         )
         assert all(
             map(
                 lambda t: len(t) == 4,
-                (dims, heads, ff_expansion, reduction_ratio, num_layers),
+                (dims, heads, ff_expansion, kernel_and_stride, num_layers),
             )
         ), "only four stages are allowed, all keyword arguments must be either a single value or a tuple of 4 values"
 
@@ -272,8 +307,8 @@ class Segformer(BaseModel):
             channels=num_chans,
             dims=dims,
             heads=heads,
-            ff_expansion=ff_expansion,
-            reduction_ratio=reduction_ratio,
+            ff_expansions=ff_expansion,
+            kernel_and_strides=kernel_and_stride,
             num_layers=num_layers,
         )
 
@@ -311,12 +346,12 @@ class Segformer(BaseModel):
     def settings(self) -> SegformerSettings:
         return self._settings
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.downsampler(x)
-        layer_outputs = self.mit(x, return_layer_outputs=True)
+        layer_outputs: list[torch.Tensor] = self.mit(x, return_layer_outputs=True)
 
-        fused = [
+        fused: list[torch.Tensor] = [
             to_fused(output) for output, to_fused in zip(layer_outputs, self.to_fused)
         ]
-        fused = torch.cat(fused, dim=1)
-        return self.upsampler(fused)
+        out: torch.Tensor = torch.cat(fused, dim=1)
+        return self.upsampler(out)

--- a/mfai/torch/models/segformer.py
+++ b/mfai/torch/models/segformer.py
@@ -12,7 +12,7 @@ from dataclasses_json import dataclass_json
 from einops import rearrange
 from torch import einsum, nn
 
-from .base import ModelABC, ModelType
+from .base import BaseModel, ModelType
 
 
 def exists(val):
@@ -207,7 +207,7 @@ class MiT(nn.Module):
         return ret
 
 
-class Segformer(ModelABC, nn.Module):
+class Segformer(BaseModel):
     """
     Segformer architecture with extra
     upsampling in the decoder to match

--- a/mfai/torch/models/segformer.py
+++ b/mfai/torch/models/segformer.py
@@ -258,8 +258,8 @@ class Segformer(BaseModel):
         out_channels: int,
         input_shape: tuple[int, int],
         settings: SegformerSettings = SegformerSettings(),
-        *args: dict[str, Any],
-        **kwargs: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
 

--- a/mfai/torch/models/unet.py
+++ b/mfai/torch/models/unet.py
@@ -15,7 +15,7 @@ import torch
 from dataclasses_json import dataclass_json
 from torch import nn
 
-from .base import AutoPaddingModel, ModelABC, ModelType
+from .base import AutoPaddingModel, BaseModel, ModelType
 from .resnet import get_resnet_encoder
 
 
@@ -64,7 +64,7 @@ class UnetSettings:
     autopad_enabled: bool = False
 
 
-class UNet(ModelABC, AutoPaddingModel, nn.Module):
+class UNet(BaseModel, AutoPaddingModel):
     """
     Returns a u_net architecture, with uninitialised weights, matching desired numbers of input and output channels.
 
@@ -238,7 +238,7 @@ class CustomUnetSettings:
     autopad_enabled: bool = False
 
 
-class CustomUnet(ModelABC, AutoPaddingModel, nn.Module):
+class CustomUnet(BaseModel, AutoPaddingModel):
     settings_kls = CustomUnetSettings
     onnx_supported = True
     supported_num_spatial_dims = (2,)

--- a/mfai/torch/models/unet.py
+++ b/mfai/torch/models/unet.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from functools import cached_property
 from math import ceil
-from typing import Tuple
+from typing import Literal, Tuple
 
 import torch
 from dataclasses_json import dataclass_json
@@ -233,7 +233,7 @@ class UNet(BaseModel, AutoPaddingModel):
 @dataclass_json
 @dataclass(slots=True)
 class CustomUnetSettings:
-    encoder_name: str = "resnet18"
+    encoder_name: Literal["resnet18", "resnet34", "resnet50"] = "resnet18"
     encoder_depth: int = 5
     encoder_weights: bool = True
     autopad_enabled: bool = False
@@ -263,7 +263,7 @@ class CustomUnet(BaseModel, AutoPaddingModel):
         self._settings = settings
 
         self.encoder = get_resnet_encoder(
-            settings.encoder_name,
+            name=settings.encoder_name,
             in_channels=in_channels,
             depth=settings.encoder_depth,
             weights=settings.encoder_weights,

--- a/mfai/torch/models/unetrpp.py
+++ b/mfai/torch/models/unetrpp.py
@@ -24,7 +24,7 @@ from monai.networks.layers.utils import get_norm_layer
 from monai.utils import optional_import
 from torch.nn.functional import scaled_dot_product_attention
 
-from .base import ModelABC, ModelType
+from .base import BaseModel, ModelType
 
 
 def _trunc_normal_(tensor, mean, std, a, b):
@@ -613,7 +613,7 @@ class UNETRPPSettings:
     attention_code: str = "torch"
 
 
-class UNETRPP(ModelABC, nn.Module):
+class UNETRPP(BaseModel):
     """
     UNETR++ based on: "Shaker et al.,
     UNETR++: Delving into Efficient and Accurate 3D Medical Image Segmentation"

--- a/mfai/torch/models/utils.py
+++ b/mfai/torch/models/utils.py
@@ -6,7 +6,12 @@ import torch
 import torch.nn as nn
 
 
-def patch_first_conv(model, new_in_channels, default_in_channels=3, pretrained=True):
+def patch_first_conv(
+    model: torch.nn.Module,
+    new_in_channels: int,
+    default_in_channels: int = 3,
+    pretrained: bool = True,
+) -> None:
     """Change first convolution layer input channels.
     In case:
         in_channels == 1 or in_channels == 2 -> reuse original weights
@@ -16,45 +21,48 @@ def patch_first_conv(model, new_in_channels, default_in_channels=3, pretrained=T
     # get first conv
     for module in model.modules():
         if isinstance(module, nn.Conv2d) and module.in_channels == default_in_channels:
+            first_conv: nn.Conv2d = module
             break
 
-    weight = module.weight.detach()
-    module.in_channels = new_in_channels
+    weight = first_conv.weight.detach()
+    first_conv.in_channels = new_in_channels
 
     if not pretrained:
-        module.weight = nn.parameter.Parameter(
+        first_conv.weight = nn.parameter.Parameter(
             torch.Tensor(
-                module.out_channels,
-                new_in_channels // module.groups,
-                *module.kernel_size,
+                first_conv.out_channels,
+                new_in_channels // first_conv.groups,
+                *first_conv.kernel_size,
             )
         )
-        module.reset_parameters()
+        first_conv.reset_parameters()
 
     elif new_in_channels == 1:
         new_weight = weight.sum(1, keepdim=True)
-        module.weight = nn.parameter.Parameter(new_weight)
+        first_conv.weight = nn.parameter.Parameter(new_weight)
 
     else:
         new_weight = torch.Tensor(
-            module.out_channels, new_in_channels // module.groups, *module.kernel_size
+            first_conv.out_channels,
+            new_in_channels // first_conv.groups,
+            *first_conv.kernel_size,
         )
 
         for i in range(new_in_channels):
             new_weight[:, i] = weight[:, i % default_in_channels]
 
         new_weight = new_weight * (default_in_channels / new_in_channels)
-        module.weight = nn.parameter.Parameter(new_weight)
+        first_conv.weight = nn.parameter.Parameter(new_weight)
 
 
-def replace_strides_with_dilation(module, dilation_rate):
+def replace_strides_with_dilation(module: torch.nn.Module, dilation: int) -> None:
     """Patch Conv2d modules replacing strides with dilation"""
     for mod in module.modules():
         if isinstance(mod, nn.Conv2d):
             mod.stride = (1, 1)
-            mod.dilation = (dilation_rate, dilation_rate)
+            mod.dilation = (dilation, dilation)
             kh, kw = mod.kernel_size
-            mod.padding = ((kh // 2) * dilation_rate, (kh // 2) * dilation_rate)
+            mod.padding = ((kh // 2) * dilation, (kh // 2) * dilation)
 
             # Kostyl for EfficientNet
             if hasattr(mod, "static_padding"):
@@ -84,13 +92,13 @@ class AbsolutePosEmdebding(nn.Module):
                 requires_grad=True,
             )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return x + self.pos_embedding
 
 
-def init_(tensor: torch.Tensor, dim_idx=-1):
-    dim = tensor.shape[dim_idx]
-    std = 1 / math.sqrt(dim)
+def init_(tensor: torch.Tensor, dim_idx: int = -1) -> torch.Tensor:
+    dim: int = tensor.shape[dim_idx]
+    std: float = 1 / math.sqrt(dim)
     tensor.uniform_(-std, std)
     return tensor
 
@@ -109,10 +117,10 @@ def features_second_to_last(y: torch.Tensor) -> torch.Tensor:
     return einops.rearrange(y, "b n x y -> b x y n").contiguous()
 
 
-def expand_to_batch(x: torch.Tensor, batch_size: int):
+def expand_to_batch(x: torch.Tensor, batch_size: int) -> torch.Tensor:
     """
     Expand tensor with initial batch dimension
     """
     # In order to be generic (for 1D or 2D grid)
-    sizes = [batch_size] + [-1 for _ in x.shape]
+    sizes: list[int] = [batch_size] + [-1 for _ in x.shape]
     return x.unsqueeze(0).expand(*sizes)

--- a/mfai/torch/namedtensor.py
+++ b/mfai/torch/namedtensor.py
@@ -73,27 +73,27 @@ class NamedTensor(TensorWrapper):
         self.feature_dim_name = feature_dim_name
 
     @property
-    def ndims(self):
+    def ndims(self) -> int:
         """
         Number of dimensions of the tensor.
         """
         return len(self.names)
 
     @property
-    def num_spatial_dims(self):
+    def num_spatial_dims(self) -> int:
         """
         Number of spatial dimensions of the tensor.
         """
         return len([x for x in self.names if x in self.SPATIAL_DIM_NAMES])
 
     @property
-    def feature_dim_idx(self):
+    def feature_dim_idx(self) -> int:
         """
         Index of the features dimension.
         """
         return self.names.index(self.feature_dim_name)
 
-    def __str__(self):
+    def __str__(self) -> str:
         head = "--- NamedTensor ---\n"
         head += f"Names: {self.names}\nTensor Shape: {self.tensor.shape})\nFeatures:\n"
         table = [
@@ -178,7 +178,7 @@ class NamedTensor(TensorWrapper):
             return nts[0].clone()
         else:
             # Check features names are distinct between the n named tensors
-            feature_names = set()
+            feature_names: set[str] = set()
             for nt in nts:
                 if feature_names & set(nt.feature_names):
                     raise ValueError(
@@ -215,7 +215,7 @@ class NamedTensor(TensorWrapper):
         """
         return self.names.index(dim_name)
 
-    def clone(self):
+    def clone(self) -> "NamedTensor":
         return NamedTensor(
             tensor=deepcopy(self.tensor).to(self.tensor.device),
             names=self.names.copy(),

--- a/mfai/torch/padding.py
+++ b/mfai/torch/padding.py
@@ -9,7 +9,6 @@ def pad_batch(
     mode: str = "constant",
     pad_value: Optional[float] = 0,
 ) -> torch.Tensor:
-
     """Given batch of 2D or 3D data and a shape new_shape,
         pads the tensor with the given pad_value.
 
@@ -46,7 +45,6 @@ def pad_batch(
         )
 
     raise ValueError("new_shape must be a torch.Size of length 2 or 3.")
-
 
 
 def _get_2D_padding(
@@ -89,7 +87,6 @@ def _get_3D_padding(
 def undo_padding(
     batch: torch.Tensor, old_shape: torch.Size, inplace: bool = False
 ) -> torch.Tensor:
-
     """Removes the padding added by pad_batch
 
     Args:
@@ -132,4 +129,3 @@ def undo_padding(
         ].clone()
     else:
         raise ValueError("old_shape must be a torch.Size of length 2 or 3.")
-

--- a/mfai/torch/padding.py
+++ b/mfai/torch/padding.py
@@ -8,7 +8,8 @@ def pad_batch(
     new_shape: torch.Size,
     mode: str = "constant",
     pad_value: Optional[float] = 0,
-) -> torch.Tensor | ValueError:
+) -> torch.Tensor:
+
     """Given batch of 2D or 3D data and a shape new_shape,
         pads the tensor with the given pad_value.
 
@@ -44,7 +45,8 @@ def pad_batch(
             batch, (left, right, top, bottom, front, back), mode=mode, value=pad_value
         )
 
-    return ValueError("new_shape must be a torch.Size of length 2 or 3.")
+    raise ValueError("new_shape must be a torch.Size of length 2 or 3.")
+
 
 
 def _get_2D_padding(
@@ -86,7 +88,8 @@ def _get_3D_padding(
 
 def undo_padding(
     batch: torch.Tensor, old_shape: torch.Size, inplace: bool = False
-) -> torch.Tensor | ValueError:
+) -> torch.Tensor:
+
     """Removes the padding added by pad_batch
 
     Args:
@@ -128,4 +131,5 @@ def undo_padding(
             left : batch.shape[-1] - right,
         ].clone()
     else:
-        return ValueError("old_shape must be a torch.Size of length 2 or 3.")
+        raise ValueError("old_shape must be a torch.Size of length 2 or 3.")
+

--- a/mfai/torch/padding.py
+++ b/mfai/torch/padding.py
@@ -2,61 +2,77 @@ import torch.nn.functional as F
 import torch
 from typing import Tuple, Optional
 
-def pad_batch(batch: torch.Tensor, new_shape: torch.Size, mode: str = "constant", pad_value: Optional[float] = 0) -> torch.Tensor | ValueError:
-    """ Given batch of 2D or 3D data and a shape new_shape, 
-        pads the tensor with the given pad_value.  
+
+def pad_batch(
+    batch: torch.Tensor,
+    new_shape: torch.Size,
+    mode: str = "constant",
+    pad_value: Optional[float] = 0,
+) -> torch.Tensor | ValueError:
+    """Given batch of 2D or 3D data and a shape new_shape,
+        pads the tensor with the given pad_value.
 
     Args:
         batch (torch.Tensor): the batch of values of shape (B, C, D, H, W) or (B, C, H, W).
-        new_shape (torch.Size): Target shape (D, H, W) for 3D tensors or (H, W) for 2D tensors to be given. 
+        new_shape (torch.Size): Target shape (D, H, W) for 3D tensors or (H, W) for 2D tensors to be given.
         pad_value (float, optional): the padding value to be used. Defaults to 0.
 
     Returns:
         torch.Tensor: The padded tensor.
     """
 
-    fits = batch.shape[-len(new_shape):] == new_shape
-    
-    if mode != 'constant':
+    fits = batch.shape[-len(new_shape) :] == new_shape
+
+    if mode != "constant":
         pad_value = None
 
     if fits:
         return batch
 
-    if len(new_shape) == 2:        
-        left, right, top, bottom = _get_2D_padding(new_shape=new_shape, old_shape=batch.shape[-len(new_shape):])
+    if len(new_shape) == 2:
+        left, right, top, bottom = _get_2D_padding(
+            new_shape=new_shape, old_shape=batch.shape[-len(new_shape) :]
+        )
 
         return F.pad(batch, (left, right, top, bottom), mode=mode, value=pad_value)
     elif len(new_shape) == 3:
-        left, right, top, bottom, front, back = _get_3D_padding(new_shape=new_shape, old_shape=batch.shape[-len(new_shape):])
+        left, right, top, bottom, front, back = _get_3D_padding(
+            new_shape=new_shape, old_shape=batch.shape[-len(new_shape) :]
+        )
 
-        return F.pad(batch, (left, right, top, bottom, front, back), mode=mode, value=pad_value)
-    
+        return F.pad(
+            batch, (left, right, top, bottom, front, back), mode=mode, value=pad_value
+        )
+
     return ValueError("new_shape must be a torch.Size of length 2 or 3.")
 
 
-def _get_2D_padding(new_shape: torch.Size, old_shape: torch.Size) -> Tuple[int, int, int, int]:
-    """ Returns the left, right, top, bottom paddings that needs to be added to a 
-        2D tensor of shape old_shape to get new_shape as a new shape. 
+def _get_2D_padding(
+    new_shape: torch.Size, old_shape: torch.Size
+) -> Tuple[int, int, int, int]:
+    """Returns the left, right, top, bottom paddings that needs to be added to a
+        2D tensor of shape old_shape to get new_shape as a new shape.
 
     Args:
         new_shape (torch.Size): the new shape
         old_shape (torch.Size): the old shape
 
     Returns:
-        Tuple[int]: left,right,top and bottom sizes to be added. 
+        Tuple[int]: left,right,top and bottom sizes to be added.
     """
-    
+
     diff_x = new_shape[1] - old_shape[-1]
     diff_y = new_shape[0] - old_shape[-2]
 
+    left, right = diff_x // 2, diff_x - (diff_x // 2)
+    top, bottom = diff_y // 2, diff_y - (diff_y // 2)
 
-    left, right = diff_x//2, diff_x - (diff_x//2)
-    top, bottom = diff_y//2, diff_y - (diff_y//2)
-    
     return left, right, top, bottom
 
-def _get_3D_padding(new_shape: torch.Size, old_shape: torch.Size) -> Tuple[int, int, int, int, int, int]:
+
+def _get_3D_padding(
+    new_shape: torch.Size, old_shape: torch.Size
+) -> Tuple[int, int, int, int, int, int]:
     diff_z = new_shape[0] - old_shape[-3]
     diff_y = new_shape[1] - old_shape[-2]
     diff_x = new_shape[2] - old_shape[-1]
@@ -64,34 +80,52 @@ def _get_3D_padding(new_shape: torch.Size, old_shape: torch.Size) -> Tuple[int, 
     left, right = diff_x // 2, diff_x - (diff_x // 2)
     top, bottom = diff_y // 2, diff_y - (diff_y // 2)
     front, back = diff_z // 2, diff_z - (diff_z // 2)
-    
+
     return left, right, top, bottom, front, back
 
 
-def undo_padding(batch: torch.Tensor, old_shape: torch.Size, inplace: bool=False) -> torch.Tensor | ValueError:
-    """ Removes the padding added by pad_batch
+def undo_padding(
+    batch: torch.Tensor, old_shape: torch.Size, inplace: bool = False
+) -> torch.Tensor | ValueError:
+    """Removes the padding added by pad_batch
 
     Args:
         batch (torch.Tensor): The padded batch of data
         old_shape (torch.Size): The original shape of the data
-        inplace (bool): Whether the returned tensor is just a sliced view of the 
-                        given tensor or a new copy. 
+        inplace (bool): Whether the returned tensor is just a sliced view of the
+                        given tensor or a new copy.
     """
-    
-    new_shape = batch.shape[-len(old_shape):]
+
+    new_shape = batch.shape[-len(old_shape) :]
     assert all(o <= n for o, n in zip(old_shape, new_shape))
-    
-    if len(old_shape) == 2: 
-        left, right, top, bottom = _get_2D_padding(new_shape=new_shape, old_shape=old_shape)
+
+    if len(old_shape) == 2:
+        left, right, top, bottom = _get_2D_padding(
+            new_shape=new_shape, old_shape=old_shape
+        )
         if inplace:
-            return batch[..., top:batch.shape[-2]-bottom, left:batch.shape[-1]-right]
-        return batch[..., top:batch.shape[-2]-bottom, left:batch.shape[-1]-right].clone()
-    elif len(old_shape) == 3: 
-        left, right, top, bottom, front, back = _get_3D_padding(new_shape=new_shape,
-                                                                old_shape=old_shape)
+            return batch[
+                ..., top : batch.shape[-2] - bottom, left : batch.shape[-1] - right
+            ]
+        return batch[
+            ..., top : batch.shape[-2] - bottom, left : batch.shape[-1] - right
+        ].clone()
+    elif len(old_shape) == 3:
+        left, right, top, bottom, front, back = _get_3D_padding(
+            new_shape=new_shape, old_shape=old_shape
+        )
         if inplace:
-            return batch[..., front:batch.shape[-3]-back, top:batch.shape[-2]-bottom, left:batch.shape[-1]-right]
-        return batch[..., front:batch.shape[-3]-back, top:batch.shape[-2]-bottom, left:batch.shape[-1]-right].clone()
+            return batch[
+                ...,
+                front : batch.shape[-3] - back,
+                top : batch.shape[-2] - bottom,
+                left : batch.shape[-1] - right,
+            ]
+        return batch[
+            ...,
+            front : batch.shape[-3] - back,
+            top : batch.shape[-2] - bottom,
+            left : batch.shape[-1] - right,
+        ].clone()
     else:
         return ValueError("old_shape must be a torch.Size of length 2 or 3.")
-    

--- a/mfai/torch/segmentation_module.py
+++ b/mfai/torch/segmentation_module.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import Callable, Literal, Tuple
+from typing import Any, Literal, Tuple
+import warnings
 
 import lightning.pytorch as pl
 import pandas as pd
@@ -7,7 +8,7 @@ import torch
 import torchmetrics as tm
 from pytorch_lightning.utilities import rank_zero_only
 
-from mfai.torch.models.base import ModelABC
+from mfai.torch.models.base import BaseModel
 
 # define custom scalar in tensorboard, to have 2 lines on same graph
 layout = {
@@ -20,30 +21,30 @@ layout = {
 class SegmentationLightningModule(pl.LightningModule):
     def __init__(
         self,
-        model: ModelABC,
+        model: BaseModel,
         type_segmentation: Literal["binary", "multiclass", "multilabel", "regression"],
-        loss: Callable,
+        loss: torch.nn.modules.loss._Loss,
     ) -> None:
         """A lightning module adapted for segmentation of weather images.
 
         Args:
-            model (ModelABC): Torch neural network model in [DeepLabV3, DeepLabV3Plus, HalfUNet, Segformer, SwinUNETR, UNet, CustomUnet, UNETRPP]
+            model (BaseModel): Torch neural network model in [DeepLabV3, DeepLabV3Plus, HalfUNet, Segformer, SwinUNETR, UNet, CustomUnet, UNETRPP]
             type_segmentation (Literal["binary", "multiclass", "multilabel", "regression"]): Type of segmentation we want to do"
-            loss (Callable): Loss function
+            loss (torch.nn.modules.loss._Loss): Loss function
         """
         super().__init__()
         self.model = model
         self.channels_last = self.model.in_channels == 3
         if self.channels_last:  # Optimizes computation for RGB images
-            self.model = self.model.to(memory_format=torch.channels_last)
+            self.model = self.model.to(memory_format=torch.channels_last)  # type: ignore[call-overload]
         self.type_segmentation = type_segmentation
         self.loss = loss
         self.metrics = self.get_metrics()
 
         # class variables to log metrics for each sample during train/test step
-        self.test_metrics = {}
-        self.training_loss = []
-        self.validation_loss = []
+        self.test_metrics: dict[int, dict[str, Any]] = {}
+        self.training_loss: list[Any] = []
+        self.validation_loss: list[Any] = []
 
         self.save_hyperparameters(ignore=["loss", "model"])
 
@@ -55,11 +56,11 @@ class SegmentationLightningModule(pl.LightningModule):
             self.model.input_shape[1],
         )
 
-    def get_metrics(self):
+    def get_metrics(self) -> torch.nn.ModuleDict:
         """Defines the metrics that will be computed during valid and test steps."""
 
         if self.type_segmentation == "regression":
-            metrics_dict = torch.nn.ModuleDict(
+            return torch.nn.ModuleDict(
                 {
                     "rmse": tm.MeanSquaredError(squared=False),
                     "mae": tm.MeanAbsoluteError(),
@@ -67,30 +68,47 @@ class SegmentationLightningModule(pl.LightningModule):
                 }
             )
         else:
-            metrics_kwargs = {"task": self.type_segmentation}
-            acc_kwargs = {"task": self.type_segmentation}
+            num_classes: int | None = None
+            average: Literal["micro", "macro", "weighted", "none"] = "micro"
+            num_labels: int | None = None
 
             if self.type_segmentation == "multiclass":
-                metrics_kwargs["num_classes"] = self.model.out_channels
-                acc_kwargs["num_classes"] = self.model.out_channels
+                num_classes = self.model.out_channels
                 # by default, average="micro" and when task="multiclass", f1 = recall = acc = precision
                 # consequently, we put average="macro" for other metrics
-                metrics_kwargs["average"] = "macro"
-                acc_kwargs["average"] = "micro"
+                average = "macro"
 
             elif self.type_segmentation == "multilabel":
-                metrics_kwargs["num_labels"] = self.model.out_channels
-                acc_kwargs["num_labels"] = self.model.out_channels
+                num_labels = self.model.out_channels
 
             metrics_dict = {
-                "acc": tm.Accuracy(**acc_kwargs),
-                "f1": tm.F1Score(**metrics_kwargs),
-                "recall_pod": tm.Recall(**metrics_kwargs),
-                "precision": tm.Precision(**metrics_kwargs),  # Precision = 1 - FAR
+                "acc": tm.Accuracy(
+                    task=self.type_segmentation,
+                    num_classes=num_classes,
+                    num_labels=num_labels,
+                ),
+                "f1": tm.F1Score(
+                    task=self.type_segmentation,
+                    num_classes=num_classes,
+                    average=average,
+                    num_labels=num_labels,
+                ),
+                "recall_pod": tm.Recall(
+                    task=self.type_segmentation,
+                    num_classes=num_classes,
+                    average=average,
+                    num_labels=num_labels,
+                ),
+                "precision": tm.Precision(  # Precision = 1 - FAR
+                    task=self.type_segmentation,
+                    num_classes=num_classes,
+                    average=average,
+                    num_labels=num_labels,
+                ),
             }
-        return torch.nn.ModuleDict(metrics_dict)
+            return torch.nn.ModuleDict(metrics_dict)
 
-    def forward(self, inputs: torch.Tensor):
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
         """Runs data through the model. Separate from training step."""
         if self.channels_last:
             inputs = inputs.to(memory_format=torch.channels_last)
@@ -99,8 +117,10 @@ class SegmentationLightningModule(pl.LightningModule):
 
         y_hat = self.model(inputs)
         return self.last_activation(y_hat)
-    
-    def _shared_forward_step(self, x: torch.Tensor, y: torch.Tensor):
+
+    def _shared_forward_step(
+        self, x: torch.Tensor, y: torch.Tensor
+    ) -> tuple[torch.Tensor, Any]:
         """Computes forward pass and loss for a batch.
         Step shared by training, validation and test steps"""
         if self.channels_last:
@@ -112,49 +132,55 @@ class SegmentationLightningModule(pl.LightningModule):
         y_hat = self.last_activation(y_hat)
 
         return y_hat, loss
-        
 
-    def on_train_start(self):
+    def on_train_start(self) -> None:
         """Setup custom scalars panel on tensorboard and log hparams.
         Useful to easily compare train and valid loss and detect overtfitting."""
-        print(f"Logs will be saved in \033[96m{self.logger.log_dir}\033[0m")
-        self.logger.experiment.add_custom_scalars(layout)
         hparams = dict(self.hparams)
         hparams["loss"] = self.loss.__class__.__name__
         hparams["model"] = self.model.__class__.__name__
-        self.logger.log_hyperparams(hparams, {"val_loss": 0, "val_f1": 0})
+        if self.logger and self.logger.log_dir:
+            print(f"Logs will be saved in \033[96m{self.logger.log_dir}\033[0m")
+            self.logger.experiment.add_custom_scalars(layout)
+            self.logger.log_hyperparams(hparams, {"val_loss": 0, "val_f1": 0})
 
-    def _shared_epoch_end(self, outputs: torch.Tensor, label: torch.Tensor):
+    def _shared_epoch_end(self, outputs: list[torch.Tensor], label: str) -> None:
         """Computes and logs the averaged loss at the end of an epoch on custom layout.
         Step shared by training and validation epochs.
         """
         avg_loss = torch.stack(outputs).mean()
-        tb = self.logger.experiment
+        tb = self.logger.experiment  # type: ignore[union-attr]
         tb.add_scalar(f"loss/{label}", avg_loss, self.current_epoch)
 
-    def training_step(self, batch: Tuple[torch.tensor, torch.tensor], batch_idx: int):
+    def training_step(
+        self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int
+    ) -> Any:
         x, y = batch
         _, loss = self._shared_forward_step(x, y)
         self.log("train_loss", loss, on_step=True, on_epoch=True, prog_bar=True)
         self.training_loss.append(loss)
         return loss
 
-    def on_train_epoch_end(self):
+    def on_train_epoch_end(self) -> None:
         self._shared_epoch_end(self.training_loss, "train")
         self.training_loss.clear()  # free memory
 
-    def val_plot_step(self, batch_idx: int, y: torch.Tensor, y_hat: torch.Tensor):
+    def val_plot_step(
+        self, batch_idx: int, y: torch.Tensor, y_hat: torch.Tensor
+    ) -> None:
         """Plots images on first batch of validation and log them in logger.
         Should be overwrited for each specific project, with matplotlib plots."""
         if batch_idx == 0:
-            tb = self.logger.experiment
+            tb = self.logger.experiment  # type: ignore[union-attr]
             step = self.current_epoch
             dformat = "HW" if self.type_segmentation == "multiclass" else "CHW"
             if step == 0:
                 tb.add_image("val_plots/true_image", y[0], dataformats=dformat)
             tb.add_image("val_plots/pred_image", y_hat[0], step, dataformats=dformat)
 
-    def validation_step(self, batch: Tuple[torch.tensor, torch.tensor], batch_idx: int):
+    def validation_step(
+        self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int
+    ) -> Any:
         x, y = batch
         y_hat, loss = self._shared_forward_step(x, y)
         self.log("val_loss", loss, on_epoch=True, sync_dist=True)
@@ -165,16 +191,20 @@ class SegmentationLightningModule(pl.LightningModule):
         self.val_plot_step(batch_idx, y, y_hat)
         return loss
 
-    def on_validation_epoch_end(self):
+    def on_validation_epoch_end(self) -> None:
         self._shared_epoch_end(self.validation_loss, "validation")
         self.validation_loss.clear()  # free memory
+        if self.logger is None:
+            return
         for metric_name, metric in self.metrics.items():
-            tb = self.logger.experiment
+            tb = self.logger.experiment  # type: ignore[attr-defined]
             # Use add scalar to log at step=current_epoch
             tb.add_scalar(f"val_{metric_name}", metric.compute(), self.current_epoch)
             metric.reset()
 
-    def test_step(self, batch: Tuple[torch.tensor, torch.tensor], batch_idx: int):
+    def test_step(
+        self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int
+    ) -> None:
         """Computes metrics for each sample, at the end of the run."""
         x, y = batch
         y_hat, loss = self._shared_forward_step(x, y)
@@ -198,17 +228,22 @@ class SegmentationLightningModule(pl.LightningModule):
 
     @rank_zero_only
     def save_test_metrics_as_csv(self, df: pd.DataFrame) -> None:
+        if self.logger is None or self.logger.log_dir is None:
+            warnings.warn(
+                "SegmentationLightningModule.save_test_metrics_as_csv() called with no logger or no local save path."
+            )
+            return
         path_csv = Path(self.logger.log_dir) / "metrics_test_set.csv"
         df.to_csv(path_csv, index=False)
         print(f"--> Metrics for all samples saved in \033[91m\033[1m{path_csv}\033[0m")
 
-    def on_test_epoch_end(self):
+    def on_test_epoch_end(self) -> None:
         """Logs metrics in logger hparams view, at the end of run."""
         df = self.build_metrics_dataframe()
         self.save_test_metrics_as_csv(df)
         df = df.drop("Name", axis=1)
 
-    def last_activation(self, y_hat: torch.Tensor):
+    def last_activation(self, y_hat: torch.Tensor) -> torch.Tensor:
         """Applies appropriate activation according to task."""
         if self.type_segmentation == "multiclass":
             y_hat = y_hat.log_softmax(dim=1).exp()
@@ -216,7 +251,7 @@ class SegmentationLightningModule(pl.LightningModule):
             y_hat = torch.nn.functional.logsigmoid(y_hat).exp()
         return y_hat
 
-    def probabilities_to_classes(self, y_hat: torch.Tensor):
+    def probabilities_to_classes(self, y_hat: torch.Tensor) -> torch.Tensor:
         """Transfrom probalistics predictions to discrete classes"""
         if self.type_segmentation == "multiclass":
             y_hat = y_hat.argmax(dim=1)
@@ -225,5 +260,5 @@ class SegmentationLightningModule(pl.LightningModule):
             y_hat = (y_hat > 0.5).int()
         return y_hat
 
-    def configure_optimizers(self):
+    def configure_optimizers(self) -> torch.optim.Adam:
         return torch.optim.Adam(self.parameters(), lr=0.001)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ Homepage = "https://github.com/meteofrance/mfai"
 [tool.mypy]
 # [mypy configuration file doc](https://mypy.readthedocs.io/en/stable/config_file.html#confval-exclude)
 exclude = [
-  '^mfai/torch/models/llms/*$',
   '^mfai/torch/models/nlam/*$',
   '^mfai/torch/models/deeplabv3.py$',
   '^mfai/torch/models/resnet.py$',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ exclude = [
   '^mfai/torch/models/llms/*$',
   '^mfai/torch/models/nlam/*$',
   '^mfai/torch/models/deeplabv3.py$',
-  '^mfai/torch/models/half_unet.py$',
   '^mfai/torch/models/resnet.py$',
   '^mfai/torch/models/segformer.py$',
   '^mfai/torch/models/swinunetr.py$',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,16 @@ Homepage = "https://github.com/meteofrance/mfai"
 [tool.mypy]
 # [mypy configuration file doc](https://mypy.readthedocs.io/en/stable/config_file.html#confval-exclude)
 exclude = [
-  '^mfai/torch/models/*$',
+  '^mfai/torch/models/llms/*$',
+  '^mfai/torch/models/nlam/*$',
+  '^mfai/torch/models/deeplabv3.py$',
+  '^mfai/torch/models/half_unet.py$',
+  '^mfai/torch/models/resnet.py$',
+  '^mfai/torch/models/segformer.py$',
+  '^mfai/torch/models/swinunetr.py$',
+  '^mfai/torch/models/unet.py$',
+  '^mfai/torch/models/unetrpp.py$',
   '^mfai/torch/namedtensor.py$',
-  '^mfai/torch/segmentation_module.py$',
 ]
 
 # Disallows defining functions without type annotations or with incomplete type annotations.
@@ -62,7 +69,9 @@ warn_unreachable = true
 
 # Disable the check for dynamically defined attributes, for more details see link below
 # [attr-defined](https://mypy.readthedocs.io/en/stable/error_code_list.html#check-that-attribute-exists-attr-defined)
-disable_error_code = "attr-defined"
+disable_error_code = [
+  "attr-defined"
+]
 
 # Configure mypy output styling
 show_error_code_links = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ exclude = [
   '^mfai/torch/models/resnet.py$',
   '^mfai/torch/models/segformer.py$',
   '^mfai/torch/models/swinunetr.py$',
-  '^mfai/torch/models/unet.py$',
   '^mfai/torch/models/unetrpp.py$',
   '^mfai/torch/namedtensor.py$',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ Homepage = "https://github.com/meteofrance/mfai"
 exclude = [
   '^mfai/torch/models/nlam/*$',
   '^mfai/torch/models/deeplabv3.py$',
-  '^mfai/torch/models/resnet.py$',
   '^mfai/torch/models/swinunetr.py$',
   '^mfai/torch/models/unetrpp.py$',
   '^mfai/torch/namedtensor.py$',
@@ -78,10 +77,10 @@ pretty = true
 # Has the effect of silencing `import-untyped` error
 [[tool.mypy.overrides]]
 module = [
-  "tiktoken_ext",
-  "tiktoken_ext.openai_public",
+  "tiktoken_ext.*",
   "sentencepiece",
   "onnxruntime",
   "pl_bolts.*",
+  "torchvision.*"
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ exclude = [
   '^mfai/torch/models/nlam/*$',
   '^mfai/torch/models/deeplabv3.py$',
   '^mfai/torch/models/resnet.py$',
-  '^mfai/torch/models/segformer.py$',
   '^mfai/torch/models/swinunetr.py$',
   '^mfai/torch/models/unetrpp.py$',
   '^mfai/torch/namedtensor.py$',

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ pytest-cov==6.0.0
 ruff==0.8.1
 mypy==1.15.0
 types-tabulate>=0.9.0
+pandas-stubs>=2.2.3

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -57,7 +57,6 @@ def test_lightning_training_loop(config):
         trainer.fit(model, datamodule.train_dataloader(), datamodule.val_dataloader())
         trainer.test(model, datamodule.test_dataloader(), ckpt_path="best")
 
-    
 
 def cli_main(args: ArgsType = None):
     cli = LightningCLI(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -195,35 +195,38 @@ def test_load_model_by_name():
             / "models"
             / "halfunet128.json",
         )
-     
-@pytest.mark.parametrize("model_class", autopad_nn_architectures)   
+
+
+@pytest.mark.parametrize("model_class", autopad_nn_architectures)
 def test_input_shape_validation(model_class):
-    
-    
-    B, C, W, H = 32,3,64,65
-    
-    input_data = torch.randn(B,C,W,H)
+    B, C, W, H = 32, 3, 64, 65
+
+    input_data = torch.randn(B, C, W, H)
     net = model_class(in_channels=C, out_channels=1)
     # assert it fails before padding
     with pytest.raises(RuntimeError):
         net(input_data)
-        
+
     valid_shape, new_shape = net.validate_input_shape(input_data.shape[-2:])
-    
+
     assert not valid_shape
-    
-    # assert it does not fail after padding 
-    input_data_pad = padding.pad_batch(batch=input_data, new_shape=new_shape, pad_value=0)
+
+    # assert it does not fail after padding
+    input_data_pad = padding.pad_batch(
+        batch=input_data, new_shape=new_shape, pad_value=0
+    )
     net(input_data_pad)
-    
-    
+
+
 @pytest.mark.parametrize("model_class", autopad_nn_architectures)
 def test_autopad_models(model_class):
-    B, C, W, H = 32,3,64,65 # invalid [W,H] 
-    
-    input_data = torch.randn(B,C,W,H)
+    B, C, W, H = 32, 3, 64, 65  # invalid [W,H]
+
+    input_data = torch.randn(B, C, W, H)
     settings = model_class.settings_kls()
-    settings.autopad_enabled = True # enable autopad
-    net = model_class(in_channels=C, out_channels=1, input_shape=(64,65), settings=settings)
-    
-    net(input_data) # assert it does not fail
+    settings.autopad_enabled = True  # enable autopad
+    net = model_class(
+        in_channels=C, out_channels=1, input_shape=(64, 65), settings=settings
+    )
+
+    net(input_data)  # assert it does not fail

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -173,27 +173,33 @@ def test_extra_models(model_and_settings):
 
 def test_load_model_by_name():
     with pytest.raises(ValueError):
-        load_from_settings_file("NotAValidModel", 2, 2, None)
+        load_from_settings_file("NotAValidModel", 2, 2, None, (1, 1))
 
     # Should work: valid settings file for this model
     load_from_settings_file(
-        "HalfUNet",
-        2,
-        2,
-        Path(__file__).parents[1] / "mfai" / "config" / "models" / "halfunet128.json",
+        model_name="HalfUNet",
+        in_channels=2,
+        out_channels=2,
+        settings_path=Path(__file__).parents[1]
+        / "mfai"
+        / "config"
+        / "models"
+        / "halfunet128.json",
+        input_shape=(10, 10, 10),
     )
 
     # Should raise: invalid settings file for this model
     with pytest.raises(ValidationError):
         load_from_settings_file(
-            "UNETRPP",
-            2,
-            2,
-            Path(__file__).parents[1]
+            model_name="UNETRPP",
+            in_channels=2,
+            out_channels=2,
+            settings_path=Path(__file__).parents[1]
             / "mfai"
             / "config"
             / "models"
             / "halfunet128.json",
+            input_shape=(10, 10, 10),
         )
 
 
@@ -202,7 +208,8 @@ def test_input_shape_validation(model_class):
     B, C, W, H = 32, 3, 64, 65
 
     input_data = torch.randn(B, C, W, H)
-    net = model_class(in_channels=C, out_channels=1)
+    net = model_class(in_channels=C, out_channels=1, input_shape=input_data.shape)
+
     # assert it fails before padding
     with pytest.raises(RuntimeError):
         net(input_data)

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -7,8 +7,6 @@ from torch import Tensor, nn
 from mfai.tokenizers import GPT2Tokenizer, LlamaTokenizer
 from mfai.torch.models.llms.multimodal import MultiModalLM, MultiModalLMSettings
 from mfai.torch.namedtensor import NamedTensor
-
-
 def generate_text_simple(
     model: nn.Module,
     idx: Tensor,
@@ -118,3 +116,38 @@ def test_multimodal_llm(
         decoded_text = tokenizer.decode(out.squeeze(0).tolist())
         print(llm_backend, tokenizer.name(), decoded_text)
         assert decoded_text == expected_text[0 if not force_vision else 1]
+
+
+def test_multimodal_clip():
+    torch.manual_seed(666)
+    tokenizer = GPT2Tokenizer()
+    model = MultiModalLM(
+        settings=MultiModalLMSettings(
+            vision_input_shape=(128, 128, 2, 1),
+            backend="gpt2",
+            n_heads=1,
+            n_layers=1,
+            emb_dim=32,
+            hidden_dim=32,
+            context_length=32,
+            inject_vision_each_stage=False,
+            vision_encoder="resnet50",
+        ),
+        vocab_size=tokenizer.vocab_size,
+    )
+    vision_input = NamedTensor(
+        torch.randn(1, 128, 128, 2, 1),
+        names=("batch", "lat", "lon", "timestep", "features"),
+        feature_names=("u",),
+    )
+    encoded = tokenizer.encode("Sustine et abstine")
+    encoded_tensor = torch.tensor(encoded).unsqueeze(0)
+
+    out = generate_text_simple(
+        model=model,
+        idx=encoded_tensor,
+        max_new_tokens=10,
+        context_size=model.context_length,
+        vision_input=vision_input,
+    )
+    tokenizer.decode(out.squeeze(0).tolist())

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -46,17 +46,45 @@ def generate_text_simple(
 @pytest.mark.parametrize(
     "llm_backend, tokenizer, expected_text",
     [
-        ("llama2", LlamaTokenizer(), ("Sustine et abstineAlignment Геrace sqlwesten Loggerлага Bushに同", "Sustine et abstine makulsion flag重глеägerhand Av Lincoln mul")),
-        ("gpt2", GPT2Tokenizer(), ("Sustine et abstinegreg LXamm Local addition Immun GlassrikeFal Resurrection", "Sustine et abstineohoorphLE updates� Oaks Coconut VC Privacy backward")),
-        ("gpt2", LlamaTokenizer(), ("Sustine et abstine współ terrestführtrange지edتズ ownershipantal", "Sustine et abstine detected *rit україн dernièreistoryikalcorüssknow")),
-        ("gpt2", GPT2Tokenizer(), ("Sustine et abstinegreg LXamm Local addition Immun GlassrikeFal Resurrection", "Sustine et abstineohoorphLE updates� Oaks Coconut VC Privacy backward")),
+        (
+            "llama2",
+            LlamaTokenizer(),
+            (
+                "Sustine et abstineAlignment Геrace sqlwesten Loggerлага Bushに同",
+                "Sustine et abstine makulsion flag重глеägerhand Av Lincoln mul",
+            ),
+        ),
+        (
+            "gpt2",
+            GPT2Tokenizer(),
+            (
+                "Sustine et abstinegreg LXamm Local addition Immun GlassrikeFal Resurrection",
+                "Sustine et abstineohoorphLE updates� Oaks Coconut VC Privacy backward",
+            ),
+        ),
+        (
+            "gpt2",
+            LlamaTokenizer(),
+            (
+                "Sustine et abstine współ terrestführtrange지edتズ ownershipantal",
+                "Sustine et abstine detected *rit україн dernièreistoryikalcorüssknow",
+            ),
+        ),
+        (
+            "gpt2",
+            GPT2Tokenizer(),
+            (
+                "Sustine et abstinegreg LXamm Local addition Immun GlassrikeFal Resurrection",
+                "Sustine et abstineohoorphLE updates� Oaks Coconut VC Privacy backward",
+            ),
+        ),
     ],
 )
 def test_multimodal_llm(
-        llm_backend: Literal["llama2", "gpt2"],
-        tokenizer: Union[GPT2Tokenizer, LlamaTokenizer],
-        expected_text: Tuple[str, str],
-    ):
+    llm_backend: Literal["llama2", "gpt2"],
+    tokenizer: Union[GPT2Tokenizer, LlamaTokenizer],
+    expected_text: Tuple[str, str],
+):
     torch.manual_seed(999)
     for force_vision in (False, True):
         model = MultiModalLM(
@@ -90,5 +118,3 @@ def test_multimodal_llm(
         decoded_text = tokenizer.decode(out.squeeze(0).tolist())
         print(llm_backend, tokenizer.name(), decoded_text)
         assert decoded_text == expected_text[0 if not force_vision else 1]
-
-

--- a/tests/test_namedtensors.py
+++ b/tests/test_namedtensors.py
@@ -188,16 +188,10 @@ def test_named_tensor():
     feature_tensor = nt_cat["feature_0"]
     assert feature_tensor.shape == (3, 1, 256, 256)
 
-    # Test iteration on batch dimension with bare_tensor=False
-    for i, nt_dim in enumerate(nt.iter_dim("batch", bare_tensor=False)):
+    # Test iteration on batch dimension
+    for i, nt_dim in enumerate(nt.iter_dim("batch")):
         assert nt_dim.tensor.shape == (256, 256, 50)
         assert nt_dim.names == ["lat", "lon", "features"]
-
-    assert i == 2
-
-    # Test iteration on batch dimension with bare_tensor=True
-    for i, tensor in enumerate(nt.iter_dim("batch", bare_tensor=True)):
-        assert tensor.shape == (256, 256, 50)
 
     assert i == 2
 
@@ -247,14 +241,14 @@ def test_named_tensor():
 
     # test select_dim when returning NamedTensor
     with pytest.raises(ValueError):
-        t = nt_cat.select_dim("features", 0, bare_tensor=False)
-    t = nt_cat.select_dim("lon", 0, bare_tensor=False)
+        t = nt_cat.select_dim("features", 0)
+    t = nt_cat.select_dim("lon", 0)
     assert t.tensor.shape == (3, 256, 30)
     assert t.feature_names == nt_cat.feature_names
     assert t.names == ["batch", "lat", "features"]
 
     # test index_select_dim when returning NamedTensor
-    t = nt_cat.index_select_dim("features", [0, 1, 2], bare_tensor=False)
+    t = nt_cat.index_select_dim("features", [0, 1, 2])
     assert t.tensor.shape == (3, 256, 256, 3)
     assert t.feature_names == nt_cat.feature_names[:3]
     assert t.names == ["batch", "lat", "lon", "features"]

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -3,34 +3,37 @@ import torch
 
 from mfai.torch.padding import pad_batch, undo_padding
 
-@pytest.mark.parametrize("dims", [2, 3])   
+
+@pytest.mark.parametrize("dims", [2, 3])
 def test_pad(dims):
-    
     # get all the True/False combinations
     combinations = torch.cartesian_prod(*[torch.tensor([0, 1]) for _ in range(dims)])
     even = 8
     odd = 9
-    mapped_combinations = torch.where(combinations == 1, torch.tensor(even),torch.tensor(odd))
-    
-    
+    mapped_combinations = torch.where(
+        combinations == 1, torch.tensor(even), torch.tensor(odd)
+    )
+
     for comb in mapped_combinations:
-    
-        # initial data with 8 batch elements, 3 channels and a combination of even and odd data dimensions 
-        tensor_shape = torch.Size([8,3]+[d for d in comb])
+        # initial data with 8 batch elements, 3 channels and a combination of even and odd data dimensions
+        tensor_shape = torch.Size([8, 3] + [d for d in comb])
         data = torch.randn(*tensor_shape)
-        
+
         # generate a new input shape, larger than the original one
         for even_delta in {True, False}:
             new_delta = [even if even_delta else odd for _ in range(dims)]
-            new_shape = torch.Size([a + b for a, b in zip(tensor_shape[-dims:], new_delta)])
-            # pad the data 
+            new_shape = torch.Size(
+                [a + b for a, b in zip(tensor_shape[-dims:], new_delta)]
+            )
+            # pad the data
             padded_data = pad_batch(batch=data, new_shape=new_shape, pad_value=0)
 
-            assert padded_data.shape[-len(new_shape):] == new_shape
-            
-            # test undo padding 
-            
-            padded_data_undone = undo_padding(padded_data, old_shape=tensor_shape[-dims:])
+            assert padded_data.shape[-len(new_shape) :] == new_shape
+
+            # test undo padding
+
+            padded_data_undone = undo_padding(
+                padded_data, old_shape=tensor_shape[-dims:]
+            )
 
             assert (padded_data_undone == data).all()
-    

--- a/tests/test_perceptual.py
+++ b/tests/test_perceptual.py
@@ -9,54 +9,54 @@ def test_perceptual_loss_on_same_img():
     """
     # Test with 3-channels images
 
-    input = torch.rand(size=(1,3,224,224))
-    # Random VGG16 
+    input = torch.rand(size=(1, 3, 224, 224))
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         in_channels=3,
         multi_scale=False,
         channel_iterative_mode=False,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = perceptual_loss.forward(input, input)
     assert pytest.approx(loss, 0.001) == 0
 
-    # Random VGG16 
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         in_channels=3,
         multi_scale=False,
         channel_iterative_mode=True,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = perceptual_loss.forward(input, input)
     assert pytest.approx(loss, 0.001) == 0
 
     # Test with single channel images
-    
-    input = torch.rand(size=(1,1,224,224))
-    # Random VGG16 
+
+    input = torch.rand(size=(1, 1, 224, 224))
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         in_channels=1,
         multi_scale=False,
         channel_iterative_mode=False,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = perceptual_loss.forward(input, input)
     assert pytest.approx(loss, 0.001) == 0
 
-    # Random VGG16 
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         in_channels=1,
         multi_scale=False,
         channel_iterative_mode=True,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = perceptual_loss.forward(input, input)
     assert pytest.approx(loss, 0.001) == 0
@@ -69,68 +69,69 @@ def test_perceptual_loss_on_different_img():
 
     # Test with 3-channels images
 
-    preds = torch.rand(size=(1,3,224,224))
-    input = torch.rand(size=(1,3,224,224))
-    # Random VGG16 
+    preds = torch.rand(size=(1, 3, 224, 224))
+    input = torch.rand(size=(1, 3, 224, 224))
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         in_channels=3,
         multi_scale=False,
         channel_iterative_mode=False,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = perceptual_loss.forward(input, preds)
     assert pytest.approx(loss, 0.001) != 0
 
-    # Random VGG16 
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         in_channels=3,
         multi_scale=False,
         channel_iterative_mode=True,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = perceptual_loss.forward(input, preds)
     assert pytest.approx(loss, 0.001) != 0
 
     # Test with  single channel images
-    
-    preds = torch.rand(size=(1,1,224,224))
-    input = torch.rand(size=(1,1,224,224))
-    # Random VGG16 
+
+    preds = torch.rand(size=(1, 1, 224, 224))
+    input = torch.rand(size=(1, 1, 224, 224))
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         in_channels=1,
         multi_scale=False,
         channel_iterative_mode=False,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = perceptual_loss.forward(input, preds)
     assert pytest.approx(loss, 0.001) != 0
 
-    # Random VGG16 
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         in_channels=1,
         multi_scale=False,
         channel_iterative_mode=True,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = perceptual_loss.forward(input, preds)
     assert pytest.approx(loss, 0.001) != 0
+
 
 def test_feature_computation():
     """
     Test of the Perceptual Loss on feature computation
     """
-    preds = torch.rand(size=(1,1,224,224))
-    # Random VGG16 
+    preds = torch.rand(size=(1, 1, 224, 224))
+    # Random VGG16
     perceptual_loss = PerceptualLoss(
-        device='cpu',
+        device="cpu",
         multi_scale=False,
         in_channels=1,
         channel_iterative_mode=False,
@@ -141,10 +142,12 @@ def test_feature_computation():
         style_block_ids=[4],
         style_layer_ids=[0],
         alpha_feature=1,
-        alpha_style=1
+        alpha_style=1,
     )
-    
-    features, styles = perceptual_loss.compute_perceptual_features(preds, return_features_and_styles=True)
+
+    features, styles = perceptual_loss.compute_perceptual_features(
+        preds, return_features_and_styles=True
+    )
     assert len(features) == 1
     assert len(styles) == 1
 
@@ -155,54 +158,54 @@ def test_lpips_on_same_img():
     """
     # Test with 3-channel images
 
-    input = torch.rand(size=(1,3,224,224))
-    # Random VGG16 
+    input = torch.rand(size=(1, 3, 224, 224))
+    # Random VGG16
     lpips = LPIPS(
-        device='cpu',
+        device="cpu",
         in_channels=3,
         multi_scale=False,
         channel_iterative_mode=False,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = lpips.forward(input, input)
     assert pytest.approx(loss, 0.001) == 0
 
-    # Random VGG16 
+    # Random VGG16
     lpips = LPIPS(
-        device='cpu',
+        device="cpu",
         in_channels=3,
         multi_scale=False,
         channel_iterative_mode=True,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = lpips.forward(input, input)
     assert pytest.approx(loss, 0.001) == 0
 
     # Test with single channel images
 
-    input = torch.rand(size=(1,1,224,224))
-    # Random VGG16 
+    input = torch.rand(size=(1, 1, 224, 224))
+    # Random VGG16
     lpips = LPIPS(
-        device='cpu',
+        device="cpu",
         in_channels=1,
         multi_scale=False,
         channel_iterative_mode=False,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = lpips.forward(input, input)
     assert pytest.approx(loss, 0.001) == 0
 
-    # Random VGG16 
+    # Random VGG16
     lpips = LPIPS(
-        device='cpu',
+        device="cpu",
         in_channels=1,
         multi_scale=False,
         channel_iterative_mode=True,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = lpips.forward(input, input)
     assert pytest.approx(loss, 0.001) == 0
@@ -212,59 +215,59 @@ def test_lpips_on_different_img():
     """
     Test of the Perceptual Loss on the different image
     """
-    
+
     # Test with 3-channel images
 
-    preds = torch.rand(size=(1,3,224,224))
-    input = torch.rand(size=(1,3,224,224))
-    # Random VGG16 
+    preds = torch.rand(size=(1, 3, 224, 224))
+    input = torch.rand(size=(1, 3, 224, 224))
+    # Random VGG16
     lpips = LPIPS(
-        device='cpu',
+        device="cpu",
         in_channels=3,
         multi_scale=False,
         channel_iterative_mode=False,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = lpips.forward(input, preds)
     assert pytest.approx(loss, 0.001) != 0
 
-    # Random VGG16 
+    # Random VGG16
     lpips = LPIPS(
-        device='cpu',
+        device="cpu",
         in_channels=3,
         multi_scale=False,
         channel_iterative_mode=True,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = lpips.forward(input, preds)
     assert pytest.approx(loss, 0.001) != 0
 
     # Test with single channel images
 
-    preds = torch.rand(size=(1,1,224,224))
-    input = torch.rand(size=(1,1,224,224))
-    # Random VGG16 
+    preds = torch.rand(size=(1, 1, 224, 224))
+    input = torch.rand(size=(1, 1, 224, 224))
+    # Random VGG16
     lpips = LPIPS(
-        device='cpu',
+        device="cpu",
         in_channels=1,
         multi_scale=False,
         channel_iterative_mode=False,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = lpips.forward(input, preds)
     assert pytest.approx(loss, 0.001) != 0
 
-    # Random VGG16 
+    # Random VGG16
     lpips = LPIPS(
-        device='cpu',
+        device="cpu",
         in_channels=1,
         multi_scale=False,
         channel_iterative_mode=True,
         pre_trained=False,
-        resize_input=False
+        resize_input=False,
     )
     loss = lpips.forward(input, preds)
     assert pytest.approx(loss, 0.001) != 0

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -31,7 +31,6 @@ def test_mini_tokenizer(base_tokenizer: Tokenizer, expected_vocab_size: int):
 ##########################################################################################################
 @pytest.mark.parametrize("base_tokenizer", [GPT2Tokenizer])
 def test_add_special_tokens(base_tokenizer: Tokenizer):
-
     tokenizer = base_tokenizer(special_tokens=set(["<|Lorem ipsum|>"]))
     assert tokenizer.vocab_size == base_tokenizer().vocab_size + 1
 


### PR DESCRIPTION
Proposition to remove the `bare_tensor: bool = True` parameter from class NamedTensor's functions that use it (`select_dim`, `index_select_dim`, `iter_dim`).

`bare_tensor` is a function parameter that exists to "switch" between 2 return types the function can have.
Encouraging the use of the `NamedTensor.tensor` class attribute removes the "hiden" default value of `bare_tensor`
```py
named_tensor.index_select_dim(dim_name, indices, bare_tensor=True)
```
becomes
```py
named_tensor.index_select_dim(dim_name, indices).tensor
```

If this change causes performance concerns, I suggest creating separate functions instead:
```py
named_tensor.index_select_dim_as_tensor(dim_name, indice)
```
