### PR TITLE
type hint mfai.models.resnet

### DIFF
--- a/mfai/torch/models/resnet.py
+++ b/mfai/torch/models/resnet.py
@@ -28,8 +28,7 @@ class ResNetEncoder(ResNet):
         del self.fc
         del self.avgpool
 
-    def get_stages(self) -> list[nn.Module]:
-        return [
+        self.stages: list[nn.Module] = [
             nn.Identity(),
             nn.Sequential(self.conv1, self.bn1, self.relu),
             nn.Sequential(self.maxpool, self.layer1),
@@ -39,11 +38,9 @@ class ResNetEncoder(ResNet):
         ]
 
     def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
-        stages = self.get_stages()
-
         features = []
         for i in range(self._depth + 1):
-            x = stages[i](x)
+            x = self.stages[i](x)
             features.append(x)
 
         return features
@@ -91,10 +88,9 @@ class ResNetEncoder(ResNet):
 
         self._output_stride = output_stride
 
-        stages = self.get_stages()
         for stage_indx, dilation in zip(stage_list, dilation_list):
             utils.replace_strides_with_dilation(
-                module=stages[stage_indx],
+                module=self.stages[stage_indx],
                 dilation=dilation,
             )
 

--- a/mfai/torch/models/resnet.py
+++ b/mfai/torch/models/resnet.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, List, Literal, Tuple, Union
+from typing import Any, Literal, Union
 
 import torch
 import torch.nn as nn
@@ -45,7 +45,7 @@ class EncoderMixin:
             model=self, new_in_channels=in_channels, pretrained=pretrained  # type:ignore [arg-type]
         )
 
-    def get_stages(self) -> List[nn.Module]:
+    def get_stages(self) -> list[nn.Module]:
         """Override it in your implementation"""
         raise NotImplementedError
 
@@ -83,7 +83,7 @@ class ResNetEncoder(ResNet, EncoderMixin):
         del self.fc
         del self.avgpool
 
-    def get_stages(self) -> List[nn.Module]:
+    def get_stages(self) -> list[nn.Module]:
         return [
             nn.Identity(),
             nn.Sequential(self.conv1, self.bn1, self.relu),
@@ -93,7 +93,7 @@ class ResNetEncoder(ResNet, EncoderMixin):
             self.layer4,
         ]
 
-    def forward(self, x: torch.Tensor) -> List[torch.Tensor]:
+    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
         stages = self.get_stages()
 
         features = []
@@ -202,7 +202,7 @@ class ResNet50(torch.nn.Module):
         self,
         num_channels: int = 3,
         num_classes: int = 1000,
-        input_shape: Union[None, Tuple[int, int]] = None,
+        input_shape: Union[None, tuple[int, int]] = None,
         settings: ResNet50Settings = ResNet50Settings(),
     ):
         super().__init__()

--- a/mfai/torch/models/unet.py
+++ b/mfai/torch/models/unet.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from functools import cached_property
 from math import ceil
-from typing import Tuple
+from typing import Literal, Tuple
 
 import torch
 from dataclasses_json import dataclass_json
@@ -233,7 +233,7 @@ class UNet(BaseModel, AutoPaddingModel):
 @dataclass_json
 @dataclass(slots=True)
 class CustomUnetSettings:
-    encoder_name: str = "resnet18"
+    encoder_name: Literal["resnet18", "resnet34", "resnet50"] = "resnet18"
     encoder_depth: int = 5
     encoder_weights: bool = True
     autopad_enabled: bool = False
@@ -263,7 +263,7 @@ class CustomUnet(BaseModel, AutoPaddingModel):
         self._settings = settings
 
         self.encoder = get_resnet_encoder(
-            settings.encoder_name,
+            name=settings.encoder_name,
             in_channels=in_channels,
             depth=settings.encoder_depth,
             weights=settings.encoder_weights,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ exclude = [
   '^mfai/torch/models/llms/*$',
   '^mfai/torch/models/nlam/*$',
   '^mfai/torch/models/deeplabv3.py$',
-  '^mfai/torch/models/resnet.py$',
   '^mfai/torch/models/segformer.py$',
   '^mfai/torch/models/swinunetr.py$',
   '^mfai/torch/models/unet.py$',
@@ -81,10 +80,10 @@ pretty = true
 # Has the effect of silencing `import-untyped` error
 [[tool.mypy.overrides]]
 module = [
-  "tiktoken_ext",
-  "tiktoken_ext.openai_public",
+  "tiktoken_ext.*",
   "sentencepiece",
   "onnxruntime",
   "pl_bolts.*",
+  "torchvision.*"
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
This type hinting is unsatisfactory because the resnet implementation uses a mixin class, and type hinting mixin classes is hard and adds a lot of complexity for the reader. The problem is well documented [here](https://stackoverflow.com/questions/77283935/how-do-i-correctly-add-type-hints-to-complex-mixin-classes)

The employed work around is to use a type ignore in `mfai.models.resnet.EncoderMixin.set_in_channels()`. The mixin problem is revealed by the fact that the `EncoderMixin` Class is not a `nn.Module`, it's implementation is.

An other work around would be to not use a mixin at all. `EncoderMixin` is only used in this model implementation and offers no reusability. The encoder capabilities of the model could be implemented directly in `ResNetEncoder`.

PR set as draft until the issue is discussed. @colon3ltocard, @LBerth.
