### PR TITLE
fix args and kwargs type hinting in half unet and segformer

### DIFF
--- a/mfai/torch/models/half_unet.py
+++ b/mfai/torch/models/half_unet.py
@@ -78,8 +78,8 @@ class HalfUNet(BaseModel, AutoPaddingModel):
         out_channels: int,
         input_shape: tuple[int, ...],
         settings: HalfUNetSettings = HalfUNetSettings(),
-        *args: dict[str, Any],
-        **kwargs: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
 

--- a/mfai/torch/models/segformer.py
+++ b/mfai/torch/models/segformer.py
@@ -258,8 +258,8 @@ class Segformer(BaseModel):
         out_channels: int,
         input_shape: tuple[int, int],
         settings: SegformerSettings = SegformerSettings(),
-        *args: dict[str, Any],
-        **kwargs: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Mypy is smart enough to know `**kwargs` means `dict[str, <something>]`. So it is sufficient to type `**kwargs: Any`