### PR TITLE
nn_architectures registry and restructured tests for models

### DIFF
--- a/mfai/torch/models/__init__.py
+++ b/mfai/torch/models/__init__.py
@@ -30,7 +30,8 @@ all_nn_architectures: list[type[ModelABC]] = list(registry.values())
 
 nn_architectures: dict[ModelType, list[type[ModelABC]]] = {
     model_type: [
-        architecture for architecture in all_nn_architectures
+        architecture
+        for architecture in all_nn_architectures
         if architecture.model_type == model_type
     ]
     for model_type in ModelType

--- a/mfai/torch/models/__init__.py
+++ b/mfai/torch/models/__init__.py
@@ -10,7 +10,7 @@ from .base import AutoPaddingModel, ModelABC, ModelType
 
 # Load all models from the torch.models package
 # which are ModelABC subclasses and have the register attribute set to True
-registry: dict[str, type[ModelABC] | type[AutoPaddingModel]] = dict()
+registry: dict[str, type[ModelABC]] = dict()
 package: ModuleType = importlib.import_module("mfai.torch.models")
 for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + "."):
     module: ModuleType = importlib.import_module(module_info.name)
@@ -26,9 +26,9 @@ for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + ".
                     f"Model {kls.__name__} from plugin {object_name} already exists in the registry."
                 )
             registry[kls.__name__] = kls
-all_nn_architectures = list(registry.values())
+all_nn_architectures: list[type[ModelABC]] = list(registry.values())
 
-nn_architectures: dict[ModelType, list[ModelABC]] = {
+nn_architectures: dict[ModelType, list[type[ModelABC]]] = {
     model_type: [
         architecture for architecture in all_nn_architectures
         if architecture.model_type == model_type

--- a/mfai/torch/models/__init__.py
+++ b/mfai/torch/models/__init__.py
@@ -28,17 +28,17 @@ for module_info in pkgutil.walk_packages(package.__path__, package.__name__ + ".
             registry[kls.__name__] = kls
 all_nn_architectures = list(registry.values())
 
+nn_architectures: dict[ModelType, list[ModelABC]] = {
+    model_type: [
+        architecture for architecture in all_nn_architectures
+        if architecture.model_type == model_type
+    ]
+    for model_type in ModelType
+}
 
 autopad_nn_architectures = {
     obj for obj in all_nn_architectures if issubclass(obj, AutoPaddingModel)
 }
-
-
-pangu_nn_architectures = set()
-for obj in all_nn_architectures:
-    if hasattr(obj, 'model_type'):
-        if obj.model_type == ModelType.PANGU:
-            pangu_nn_architectures.add(obj)
 
 
 def load_from_settings_file(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ module = [
   "sentencepiece",
   "onnxruntime",
   "pl_bolts.*",
-  "torchvision.*"
+  "torchvision.*",
+  "timm.*",
 ]
 ignore_missing_imports = true

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -234,7 +234,7 @@ def test_torch_pangu_training_loop(model_kls):
 
         # Simulate 2 EPOCHS of training
         for _ in range(2):
-            for _, data in enumerate(training_loader):
+            for data in training_loader:
                 # Zero your gradients for every batch!
                 optimizer.zero_grad()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,8 +19,8 @@ from marshmallow.exceptions import ValidationError
 from mfai.torch import export_to_onnx, onnx_load_and_infer
 from mfai.torch.models import (
     all_nn_architectures,
+    nn_architectures,
     autopad_nn_architectures,
-    pangu_nn_architectures,
     load_from_settings_file,
 )
 
@@ -115,44 +115,6 @@ def train_model(model: torch.nn.Module, input_shape: Tuple[int, ...]):
     return model
 
 
-def train_pangu_model(
-        model: torch.nn.Module, 
-        input_shape: Tuple[int, ...],
-        surface_variables: int,
-        plevel_variables: int,
-        plevels: int,
-        static_length: int
-        ):
-    optimizer = torch.optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
-    loss_fn = torch.nn.MSELoss()
-
-    ds = FakePanguDataset(input_shape, surface_variables, plevel_variables, plevels, static_length)
-
-    training_loader = torch.utils.data.DataLoader(ds, batch_size=2)
-
-    # Simulate 2 EPOCHS of training
-    for _ in range(2):
-        for _, data in enumerate(training_loader):
-            # Zero your gradients for every batch!
-            optimizer.zero_grad()
-
-            # Make predictions for this batch
-            output_plevel, output_surface = model(data['input_plevel'], data['input_surface'], data['input_static'])
-
-            # Compute the loss and its gradients
-            loss = loss_fn(output_plevel, data['target_plevel']) + loss_fn(output_surface, data['target_surface'])
-            loss.backward()
-
-            # Adjust learning weights
-            optimizer.step()
-
-    # Make a prediction in eval mode
-    model.eval()
-    sample = ds[0]
-    model(sample['input_plevel'].unsqueeze(0), sample['input_surface'].unsqueeze(0), sample['input_static'].unsqueeze(0))
-    return model
-
-
 def meshgrid(grid_width: int, grid_height: int):
     x = np.arange(0, grid_width, 1)
     y = np.arange(0, grid_height, 1)
@@ -160,8 +122,8 @@ def meshgrid(grid_width: int, grid_height: int):
     return torch.from_numpy(np.asarray([xx, yy]))
 
 
-@pytest.mark.parametrize("model_kls", all_nn_architectures)
-def test_torch_training_loop(model_kls):
+@pytest.mark.parametrize("model_kls", nn_architectures[ModelType.GRAPH])
+def test_torch_graph_training_loop(model_kls):
     """
     Checks that our models are trainable on a toy problem (sum).
     """
@@ -172,48 +134,59 @@ def test_torch_training_loop(model_kls):
     settings = model_kls.settings_kls()
 
     # for GNN models we test them with a fake 2d regular grid
-    if model_kls.model_type == ModelType.GRAPH:
-        if hasattr(model_kls, "rank_zero_setup"):
-            model_kls.rank_zero_setup(settings, meshgrid(64, 64))
+    if hasattr(model_kls, "rank_zero_setup"):
+        model_kls.rank_zero_setup(settings, meshgrid(64, 64))
 
-        if model_kls.features_last:
-            input_shape = (64 * 64, NUM_INPUTS)
-        else:
-            input_shape = (NUM_INPUTS, 64 * 64)
+    if model_kls.features_last:
+        input_shape = (64 * 64, NUM_INPUTS)
+    else:
+        input_shape = (NUM_INPUTS, 64 * 64)
+
+    model = model_kls(
+        in_channels=NUM_INPUTS,
+        out_channels=NUM_OUTPUTS,
+        input_shape=input_shape,
+        settings=settings,
+    )
+
+    model = train_model(model, input_shape)
+
+
+@pytest.mark.parametrize(
+        "model_kls",
+        nn_architectures[ModelType.CONVOLUTIONAL] + nn_architectures[ModelType.VISION_TRANSFORMER])
+def test_torch_convolutional_and_vision_transformer_training_loop(model_kls):
+    """
+    Checks that our models are trainable on a toy problem (sum).
+    """
+    INPUT_SHAPE = (64, 64, 64)
+    NUM_INPUTS = 2
+    NUM_OUTPUTS = 1
+
+    settings = model_kls.settings_kls()
+
+    # We test the model for all supported input spatial dimensions
+    for spatial_dims in model_kls.supported_num_spatial_dims:
+        if hasattr(settings, "spatial_dims"):
+            settings.spatial_dims = spatial_dims
 
         model = model_kls(
             in_channels=NUM_INPUTS,
             out_channels=NUM_OUTPUTS,
-            input_shape=input_shape,
+            input_shape=INPUT_SHAPE[:spatial_dims],
             settings=settings,
         )
+        model = train_model(model, (NUM_INPUTS, *INPUT_SHAPE[:spatial_dims]))
 
-        model = train_model(model, input_shape)
+        # We test if models claiming to be onnx exportable really are post training.
+        # See https://pytorch.org/tutorials/beginner/onnx/export_simple_model_to_onnx_tutorial.html
+        if model.onnx_supported:
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".onnx") as dst:
+                sample = torch.rand(1, NUM_INPUTS, *INPUT_SHAPE[:spatial_dims])
+                export_to_onnx(model, sample, dst.name)
+                onnx_load_and_infer(dst.name, sample)
 
-    elif model_kls.model_type != ModelType.PANGU:
-        # We test the model for all supported input spatial dimensions
-        for spatial_dims in model_kls.supported_num_spatial_dims:
-            if hasattr(settings, "spatial_dims"):
-                settings.spatial_dims = spatial_dims
-
-            model = model_kls(
-                in_channels=NUM_INPUTS,
-                out_channels=NUM_OUTPUTS,
-                input_shape=INPUT_SHAPE[:spatial_dims],
-                settings=settings,
-            )
-            model = train_model(model, (NUM_INPUTS, *INPUT_SHAPE[:spatial_dims]))
-
-            # We test if models claiming to be onnx exportable really are post training.
-            # See https://pytorch.org/tutorials/beginner/onnx/export_simple_model_to_onnx_tutorial.html
-            if model.onnx_supported:
-                with tempfile.NamedTemporaryFile(mode="w", suffix=".onnx") as dst:
-                    sample = torch.rand(1, NUM_INPUTS, *INPUT_SHAPE[:spatial_dims])
-                    export_to_onnx(model, sample, dst.name)
-                    onnx_load_and_infer(dst.name, sample)
-
-
-@pytest.mark.parametrize("model_kls", pangu_nn_architectures)
+@pytest.mark.parametrize("model_kls", nn_architectures[ModelType.PANGU])
 def test_torch_pangu_training_loop(model_kls):
     """
     Checks that our models are trainable on a toy problem (sum).
@@ -242,14 +215,40 @@ def test_torch_pangu_training_loop(model_kls):
             input_shape=INPUT_SHAPE[:spatial_dims],
             settings=settings,
         )
-        model = train_pangu_model(
-            model, 
-            INPUT_SHAPE[:spatial_dims], 
-            SURFACE_VARIABLES,
-            PLEVEL_VARIABLES,
-            PLEVELS,
-            STATIC_LENGTH
-            )
+
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
+        loss_fn = torch.nn.MSELoss()
+
+        ds = FakePanguDataset(
+            input_shape=INPUT_SHAPE[:spatial_dims],
+            surface_variables=SURFACE_VARIABLES,
+            plevel_variables=PLEVEL_VARIABLES,
+            plevels=PLEVELS,
+            static_length=STATIC_LENGTH
+        )
+
+        training_loader = torch.utils.data.DataLoader(ds, batch_size=2)
+
+        # Simulate 2 EPOCHS of training
+        for _ in range(2):
+            for _, data in enumerate(training_loader):
+                # Zero your gradients for every batch!
+                optimizer.zero_grad()
+
+                # Make predictions for this batch
+                output_plevel, output_surface = model(data['input_plevel'], data['input_surface'], data['input_static'])
+
+                # Compute the loss and its gradients
+                loss = loss_fn(output_plevel, data['target_plevel']) + loss_fn(output_surface, data['target_surface'])
+                loss.backward()
+
+                # Adjust learning weights
+                optimizer.step()
+
+        # Make a prediction in eval mode
+        model.eval()
+        sample = ds[0]
+        model(sample['input_plevel'].unsqueeze(0), sample['input_surface'].unsqueeze(0), sample['input_static'].unsqueeze(0))
 
         # We test if models claiming to be onnx exportable really are post training.
         # See https://pytorch.org/tutorials/beginner/onnx/export_simple_model_to_onnx_tutorial.html


### PR DESCRIPTION
Define a `nn_architectures: dict[ModelType, list[ModelABC]]`  registry in `mfai.torch.models`.
Allows for an easier implementation of tests on models that have different contract interface.

Reveals that there are no models of model type `ModelType.LLM` or `ModelType.MULTIMODLA_LLM` currently in mfai.
So there are no tests written for them.

Restructuration of tests goes from:
```python
@pytest.mark.parametrize("model_kls", all_nn_architectures)
def test_torch_training_loop(model_kls):
    ....
    if model.model_type is ...
    ...
    else:
```
to
```python
@pytest.mark.parametrize("model_kls", nn_architectures[ModelType.GRAPH])
def test_torch_graph_training_loop(model_kls):
    ...
    
@pytest.mark.parametrize(
        "model_kls",
        nn_architectures[ModelType.CONVOLUTIONAL] + nn_architectures[ModelType.VISION_TRANSFORMER])
def test_torch_convolutional_and_vision_transformer_training_loop(model_kls):
    ...

@pytest.mark.parametrize("model_kls", nn_architectures[ModelType.PANGU])
def test_torch_pangu_training_loop(model_kls):
    ...
```

And each model type can have its own test function.