### PR TITLE
rename torch.Tensor to Tensor

### DIFF
--- a/doc/namedtensor.md
+++ b/doc/namedtensor.md
@@ -34,14 +34,14 @@ Table of Contents:
 - **`feature_names`**: A list of names for the features along the last dimension of the tensor.
 - **`feature_names_to_idx`**: A dictionary mapping feature names to their indices.
 - **`feature_dim_name`**: The name of the feature dimension.
-- **`tensor`**: The `torch.Tensor`.
+- **`tensor`**: The `Tensor`.
 
 ## Methods
 
-### `__init__(self, tensor: torch.Tensor, names: List[str], feature_names: List[str], feature_dim_name: str = "features")`
+### `__init__(self, tensor: Tensor, names: List[str], feature_names: List[str], feature_dim_name: str = "features")`
 Initializes a **NamedTensor** instance.
 
-### `expand_to_batch_like(tensor: torch.Tensor, other: "NamedTensor") -> "NamedTensor"`
+### `expand_to_batch_like(tensor: Tensor, other: "NamedTensor") -> "NamedTensor"`
 Creates a new **NamedTensor** with the same names and feature names as another **NamedTensor** with an extra first dimension called 'batch' using the supplied tensor.
 
 ### `spatial_dim_idx(self) -> List[int]`
@@ -56,14 +56,14 @@ Returns a string representation of the **NamedTensor** with useful statistics.
 ### `select(self, dim_name: str, index: int) -> "NamedTensor"`
 Returns the tensor indexed along the dimension `dim_name` with the desired index. The given dimension is removed from the tensor.
 
-### `index_select_dim(self, dim_name: str, indices: torch.Tensor) -> "NamedTensor"`
+### `index_select_dim(self, dim_name: str, indices: Tensor) -> "NamedTensor"`
 Returns the tensor indexed along the dimension `dim_name` with the indices tensor. The returned tensor has the same number of dimensions as the original tensor. The `dim_name` dimension has the same size as the length of `indices`; other dimensions have the same size as in the original tensor.
 See https://pytorch.org/docs/stable/generated/torch.index_select.html.
 
-### `index_select_tensor_dim(self, dim_name: str, indices: torch.Tensor) -> torch.Tensor`
-Same as [index_select_dim](#index_select_dimself-dim_name-str-indices-torchtensor---namedtensor) but returns a torch.Tensor.
+### `index_select_tensor_dim(self, dim_name: str, indices: Tensor) -> Tensor`
+Same as [index_select_dim](#index_select_dimself-dim_name-str-indices-torchtensor---namedtensor) but returns a Tensor.
 
-### `new_like(cls, tensor: torch.Tensor, other: "NamedTensor") -> "NamedTensor"`
+### `new_like(cls, tensor: Tensor, other: "NamedTensor") -> "NamedTensor"`
 Creates a new **NamedTensor** with the same names but different data.
 
 ### `flatten_(self, new_dim_name: str, dim1: int, dim2: int)`
@@ -84,8 +84,8 @@ Stacks a list of **NamedTensor** instances along a new dimension.
 ### `iter_dim(self, dim_name: str) -> Iterable["NamedTensor"]`
 Iterates over the specified dimension, yielding **NamedTensor** instances.
 
-### `iter_tensor_dim(self, dim_name: str) -> Iterable[torch.Tensor]`
-Iterates over the specified dimension, yielding **torch.Tensor** instances.
+### `iter_tensor_dim(self, dim_name: str) -> Iterable[Tensor]`
+Iterates over the specified dimension, yielding **Tensor** instances.
 
 ### `type_(self, new_type)`
 Modifies the type of the underlying torch tensor by calling torch's `.type` method. This is an in-place operation for this class, the internal tensor is replaced by the new one.
@@ -161,7 +161,7 @@ selected_tensor = nt.select_tensor_dim("lat", 0)
 assert selected_named_tensor.tensor == selected_tensor
 
 # Return the tensor indexed along the dimension dim_name with the indices tensor. The returned tensor has the same number of dimensions as the original tensor (input). The dim_name dimension has the same size as the length of indices; other dimensions have the same size as in the original tensor.
-indexed_tensor = nt.index_select_dim("features", torch.tensor([0, 2]))
+indexed_tensor = nt.index_select_dim("features", Tensor([0, 2]))
 ```
 
 ### Iteration
@@ -178,7 +178,7 @@ nt = NamedTensor(
 for named_tensor in nt.iter_dim("batch"):
     print(named_tensor)
 
-# Iterate over the 'batch' dimension, yielding torch.Tensor instances
+# Iterate over the 'batch' dimension, yielding Tensor instances
 for tensor in nt.iter_tensor_dim("batch"):
     print(tensor.shape)
 ```

--- a/mfai/tokenizers/__init__.py
+++ b/mfai/tokenizers/__init__.py
@@ -177,7 +177,6 @@ class MiniGPT2Tokenizer(Tokenizer, ABC):
 
         self.add_special_tokens(["<|endoftext|>"])
 
-
     def add_special_tokens(self, special_tokens: list[str]) -> None:
         """
         Method to add some special tokens to the tokenizer.
@@ -186,7 +185,7 @@ class MiniGPT2Tokenizer(Tokenizer, ABC):
         https://github.com/openai/tiktoken/tree/main?tab=readme-ov-file#extending-tiktoken
         """
         self.gpt2_tokenizer.add_special_tokens(special_tokens)
- 
+
         vocab_size = self.vocab_size
         for i, special_token in enumerate(self.gpt2_tokenizer.special_tokens):
             mini_tok_id = vocab_size + i

--- a/mfai/torch/__init__.py
+++ b/mfai/torch/__init__.py
@@ -5,22 +5,22 @@ import numpy
 import onnx
 import onnxruntime
 import torch
-from torch import nn
+from torch import Tensor, nn
 
 
-def to_numpy(tensor: torch.Tensor) -> numpy.ndarray:
+def to_numpy(tensor: Tensor) -> numpy.ndarray:
     return (
         tensor.detach().cpu().numpy() if tensor.requires_grad else tensor.cpu().numpy()
     )
 
 
 def export_to_onnx(
-    model: nn.Module, sample: torch.Tensor | tuple[Any], filepath: Path | str
+    model: nn.Module, sample: Tensor | tuple[Any], filepath: Path | str
 ) -> None:
     """
     Exports a model to ONNX format.
     """
-    if isinstance(sample, torch.Tensor):
+    if isinstance(sample, Tensor):
         sample = (sample,)
 
     if isinstance(filepath, Path):
@@ -42,7 +42,7 @@ def export_to_onnx(
     )
 
 
-def onnx_load_and_infer(filepath: Path, sample: torch.Tensor) -> numpy.ndarray:
+def onnx_load_and_infer(filepath: Path, sample: Tensor) -> numpy.ndarray:
     """
     Loads a model using onnx, checks it, and performs an inference.
     """

--- a/mfai/torch/dummy_dataset.py
+++ b/mfai/torch/dummy_dataset.py
@@ -3,6 +3,7 @@ import random
 
 from lightning.pytorch.core import LightningDataModule
 import torch
+from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
 
 from .namedtensor import NamedTensor
@@ -43,7 +44,7 @@ class DummyDataset(Dataset):
     def __len__(self) -> int:
         return self.len
 
-    def __getitem__(self, index: int) -> tuple[torch.Tensor, torch.Tensor]:
+    def __getitem__(self, index: int) -> tuple[Tensor, Tensor]:
         x = torch.randn((self.nb_input_channels, self.dim_x, self.dim_y)).float()
         if self.task == "multiclass":
             y = torch.randint(
@@ -165,7 +166,7 @@ class DummyMultiModalDataset(Dataset):
     def __len__(self) -> int:
         return self.len
 
-    def __getitem__(self, index: int) -> tuple[NamedTensor, torch.Tensor, torch.Tensor]:
+    def __getitem__(self, index: int) -> tuple[NamedTensor, Tensor, Tensor]:
         # Create the random vision input
         x = torch.randn((self.nb_input_channels, self.dim_x, self.dim_y)).float()
         images = NamedTensor(
@@ -227,12 +228,12 @@ class DummyMultiModalDataModule(LightningDataModule):
         self.eot_token = self.dummy_train.eot_token
 
     def collate_fn_fit(
-        self, batch: List[Tuple[NamedTensor, torch.Tensor, torch.Tensor]]
-    ) -> Tuple[NamedTensor, torch.Tensor, torch.Tensor]:
+        self, batch: List[Tuple[NamedTensor, Tensor, Tensor]]
+    ) -> Tuple[NamedTensor, Tensor, Tensor]:
         """Collate a batch of multimodal data."""
         images: list[NamedTensor]
-        input_txt: list[torch.Tensor]
-        targets: list[torch.Tensor]
+        input_txt: list[Tensor]
+        targets: list[Tensor]
         images, input_txt, targets = zip(*batch)  # type: ignore[assignment]
         return (
             NamedTensor.collate_fn(images),
@@ -241,8 +242,8 @@ class DummyMultiModalDataModule(LightningDataModule):
         )
 
     def collate_text(
-        self, batch: List[torch.Tensor], target: bool = False, prompt: bool = False
-    ) -> torch.Tensor:
+        self, batch: List[Tensor], target: bool = False, prompt: bool = False
+    ) -> Tensor:
         """Collate a batch of text tensors."""
         batch_max_len = max([len(text) for text in batch]) + 1
         new_texts = []

--- a/mfai/torch/lightning_modules/clip.py
+++ b/mfai/torch/lightning_modules/clip.py
@@ -6,6 +6,7 @@ from typing import Literal, Tuple
 
 import lightning.pytorch as pl
 import torch
+from torch import Tensor
 import torch.nn.functional as F
 from pl_bolts.optimizers.lr_scheduler import LinearWarmupCosineAnnealingLR
 from torch.optim import AdamW
@@ -32,14 +33,12 @@ class CLIPLightningModule(pl.LightningModule):
 
         self.save_hyperparameters()
 
-    def forward(
-        self, images: NamedTensor, texts: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, images: NamedTensor, texts: Tensor) -> Tuple[Tensor, Tensor]:
         return self.model(texts, images)
 
     def _shared_forward_step(
-        self, batch: Tuple[NamedTensor, torch.Tensor, torch.Tensor]
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self, batch: Tuple[NamedTensor, Tensor, Tensor]
+    ) -> Tuple[Tensor, Tensor]:
         images, texts, _ = batch
 
         if len(images.tensor.shape) == 5:
@@ -99,8 +98,8 @@ class CLIPLightningModule(pl.LightningModule):
             return optimizer
 
     def training_step(
-        self, batch: Tuple[NamedTensor, torch.Tensor, torch.Tensor], batch_idx: int
-    ) -> torch.Tensor:
+        self, batch: Tuple[NamedTensor, Tensor, Tensor], batch_idx: int
+    ) -> Tensor:
         _, loss = self._shared_forward_step(batch)
 
         self.log(
@@ -109,8 +108,8 @@ class CLIPLightningModule(pl.LightningModule):
         return loss
 
     def validation_step(
-        self, batch: Tuple[NamedTensor, torch.Tensor, torch.Tensor], batch_idx: int
-    ) -> torch.Tensor:
+        self, batch: Tuple[NamedTensor, Tensor, Tensor], batch_idx: int
+    ) -> Tensor:
         _, loss = self._shared_forward_step(batch)
 
         self.log("val_loss", loss, on_epoch=True, logger=True, sync_dist=True)

--- a/mfai/torch/losses/perceptual.py
+++ b/mfai/torch/losses/perceptual.py
@@ -273,7 +273,7 @@ class PerceptualLoss(torch.nn.Module):
 
         features_x, styles_x = self._forward_net_single_img(x)
 
-        loss = Tensor(0.0).to(self.device)
+        loss = torch.tensor(0.0).to(self.device)
         for i, _ in enumerate(self.blocks):
             if i in self.feature_block_ids:
                 x = features_x[i]
@@ -314,7 +314,7 @@ class PerceptualLoss(torch.nn.Module):
 
         """
 
-        perceptual_loss = Tensor(0.0).to(self.device)
+        perceptual_loss = torch.tensor(0.0).to(self.device)
 
         # Check that tensors are normalized
         if x.max() > 1 or x.min() < 0:

--- a/mfai/torch/losses/perceptual.py
+++ b/mfai/torch/losses/perceptual.py
@@ -4,7 +4,8 @@ import torch
 from typing import Sequence
 from collections import OrderedDict
 from itertools import chain
-import torch.nn as nn
+import torch.nn as Tensor
+import nn
 import torchvision.models as models
 from urllib.error import URLError
 
@@ -130,8 +131,8 @@ class PerceptualLoss(torch.nn.Module):
         return blocks
 
     def _downscale(
-        self, x: torch.Tensor, scale_times: int = 1, mode: str = "bilinear"
-    ) -> torch.Tensor:
+        self, x: Tensor, scale_times: int = 1, mode: str = "bilinear"
+    ) -> Tensor:
         for _ in range(scale_times):
             x = torch.nn.functional.interpolate(x, scale_factor=0.5, mode=mode)
 
@@ -155,11 +156,11 @@ class PerceptualLoss(torch.nn.Module):
 
         self.blocks = torch.nn.ModuleList(blocks)
 
-    def _forward_net_single_img(self, x: torch.Tensor) -> tuple:
+    def _forward_net_single_img(self, x: Tensor) -> tuple:
         r"""Forward the Network features and styles for a single image.
 
         Arguments :
-            x: (torch.Tensor)
+            x: (Tensor)
 
         Return :
             features : (list)
@@ -203,12 +204,12 @@ class PerceptualLoss(torch.nn.Module):
         return features, styles
 
     def compute_perceptual_features(
-        self, x: torch.Tensor, return_features_and_styles: bool = False
+        self, x: Tensor, return_features_and_styles: bool = False
     ) -> tuple:
         r"""Compute the features of a single image.
 
         Arguments :
-            x: (torch.Tensor)
+            x: (Tensor)
             return_features_and_styles: (bool)
 
         Example :
@@ -257,12 +258,12 @@ class PerceptualLoss(torch.nn.Module):
             return None, None
 
     def _perceptual_loss_given_features_and_target(
-        self, x: torch.Tensor, features_y: list, styles_y: list
-    ) -> torch.Tensor:
+        self, x: Tensor, features_y: list, styles_y: list
+    ) -> Tensor:
         r"""Computes the Perceptual Loss given features and a target image.
 
         Arguments :
-            x: (torch.Tensor)
+            x: (Tensor)
             features_y : (list)
             styles_y : (list)
 
@@ -272,7 +273,7 @@ class PerceptualLoss(torch.nn.Module):
 
         features_x, styles_x = self._forward_net_single_img(x)
 
-        loss = torch.tensor(0.0).to(self.device)
+        loss = Tensor(0.0).to(self.device)
         for i, _ in enumerate(self.blocks):
             if i in self.feature_block_ids:
                 x = features_x[i]
@@ -286,14 +287,12 @@ class PerceptualLoss(torch.nn.Module):
                 loss += self.alpha_style * loss_style
         return loss
 
-    def _perceptual_loss_given_input_and_target(
-        self, x: torch.Tensor, y: torch.Tensor
-    ) -> torch.Tensor:
+    def _perceptual_loss_given_input_and_target(self, x: Tensor, y: Tensor) -> Tensor:
         r"""Computes the Perceptual Loss between two images
 
         Arguments :
-            x: (torch.Tensor)
-            y: (torch.Tensor)
+            x: (Tensor)
+            y: (Tensor)
 
         Return :
             loss : (troch.Tensor)"""
@@ -304,18 +303,18 @@ class PerceptualLoss(torch.nn.Module):
             x=y, features_y=features_x, styles_y=styles_x
         )
 
-    def forward(self, x: torch.Tensor, y: torch.Tensor | None = None) -> torch.Tensor:
+    def forward(self, x: Tensor, y: Tensor | None = None) -> Tensor:
         r"""Computes the Perceptual loss between two images
         Arguments :
-            x: (torch.Tensor)
-            y: (torch.Tensor) (default=None)
+            x: (Tensor)
+            y: (Tensor) (default=None)
 
         Note :
             If y is None, the features of y needs to be computed before by calling the function : compute_perceptual_features
 
         """
 
-        perceptual_loss = torch.tensor(0.0).to(self.device)
+        perceptual_loss = Tensor(0.0).to(self.device)
 
         # Check that tensors are normalized
         if x.max() > 1 or x.min() < 0:
@@ -479,7 +478,7 @@ class LPIPS(nn.Module):
 
         return new_state_dict
 
-    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor, y: Tensor) -> Tensor:
         feat_x, _ = self.perceptual_loss.compute_perceptual_features(
             x, return_features_and_styles=True
         )
@@ -524,17 +523,17 @@ class BaseNet(nn.Module):
         super().__init__()
 
         # register buffer
-        self.mean = torch.Tensor([-0.030, -0.088, -0.188])[None, :, None, None]
-        self.std = torch.Tensor([0.458, 0.448, 0.450])[None, :, None, None]
+        self.mean = Tensor([-0.030, -0.088, -0.188])[None, :, None, None]
+        self.std = Tensor([0.458, 0.448, 0.450])[None, :, None, None]
 
     def set_requires_grad(self, state: bool) -> None:
         for param in chain(self.parameters(), self.buffers()):
             param.requires_grad = state
 
-    def z_score(self, x: torch.Tensor) -> torch.Tensor:
+    def z_score(self, x: Tensor) -> Tensor:
         return (x - self.mean) / self.std
 
-    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+    def forward(self, x: Tensor) -> list[Tensor]:
         raise NotImplementedError
 
 
@@ -555,7 +554,7 @@ class VGG16(BaseNet):
 
         self.set_requires_grad(False)
 
-    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+    def forward(self, x: Tensor) -> list[Tensor]:
         x = self.z_score(x)
 
         output = []
@@ -568,7 +567,7 @@ class VGG16(BaseNet):
         return output
 
 
-def normalize_activation(x: torch.Tensor, eps: float = 1e-10) -> torch.Tensor:
+def normalize_activation(x: Tensor, eps: float = 1e-10) -> Tensor:
     norm_factor = torch.sqrt(torch.sum(x**2, dim=1, keepdim=True))
     return x / (norm_factor + eps)
 

--- a/mfai/torch/losses/perceptual.py
+++ b/mfai/torch/losses/perceptual.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # type: ignore
 import torch
+from torch import Tensor
 from typing import Sequence
 from collections import OrderedDict
 from itertools import chain
-import torch.nn as Tensor
-import nn
+import torch.nn as nn
 import torchvision.models as models
 from urllib.error import URLError
 

--- a/mfai/torch/metrics.py
+++ b/mfai/torch/metrics.py
@@ -40,8 +40,8 @@ class FNR(Metric):
         full_state_update = True  # noqa
         self.true_positives: Tensor
         self.false_negatives: Tensor
-        self.add_state("true_positives", default=Tensor(0), dist_reduce_fx="sum")
-        self.add_state("false_negatives", default=Tensor(0), dist_reduce_fx="sum")
+        self.add_state("true_positives", default=torch.tensor(0), dist_reduce_fx="sum")
+        self.add_state("false_negatives", default=torch.tensor(0), dist_reduce_fx="sum")
 
     def update(self, preds: Tensor, target: Tensor) -> None:
         assert preds.shape == target.shape

--- a/mfai/torch/metrics.py
+++ b/mfai/torch/metrics.py
@@ -2,6 +2,7 @@ from typing import Any, Literal, Optional
 
 from einops import rearrange
 import torch
+from torch import Tensor
 import torch.nn.functional as F
 from torchmetrics import Metric, Precision, PrecisionRecallCurve
 from torchmetrics.utilities.compute import _auc_compute
@@ -22,7 +23,7 @@ class FAR(Metric):
     def update(self, *args: Any, **kwargs: Any) -> None:
         self.p.update(*args, **kwargs)
 
-    def compute(self) -> torch.Tensor:
+    def compute(self) -> Tensor:
         return 1 - self.p.compute()
 
 
@@ -37,18 +38,18 @@ class FNR(Metric):
     def __init__(self) -> None:
         super().__init__()
         full_state_update = True  # noqa
-        self.true_positives: torch.Tensor
-        self.false_negatives: torch.Tensor
-        self.add_state("true_positives", default=torch.tensor(0), dist_reduce_fx="sum")
-        self.add_state("false_negatives", default=torch.tensor(0), dist_reduce_fx="sum")
+        self.true_positives: Tensor
+        self.false_negatives: Tensor
+        self.add_state("true_positives", default=Tensor(0), dist_reduce_fx="sum")
+        self.add_state("false_negatives", default=Tensor(0), dist_reduce_fx="sum")
 
-    def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
+    def update(self, preds: Tensor, target: Tensor) -> None:
         assert preds.shape == target.shape
         preds = torch.where(preds >= 0.5, 1, 0)
         self.true_positives += torch.sum((preds == 1) & (target == 1))
         self.false_negatives += torch.sum((preds == 0) & (target == 1))
 
-    def compute(self) -> torch.Tensor:
+    def compute(self) -> Tensor:
         return self.false_negatives / (self.true_positives + self.false_negatives)
 
 
@@ -60,11 +61,11 @@ class PR_AUC(Metric):
         full_state_update = True  # noqa
         self.task = task
 
-    def update(self, preds: torch.Tensor, targets: torch.Tensor) -> None:
+    def update(self, preds: Tensor, targets: Tensor) -> None:
         pr_curve = PrecisionRecallCurve(task=self.task)
         self.precision, self.recall, _ = pr_curve(preds, targets)
 
-    def compute(self) -> torch.Tensor:
+    def compute(self) -> Tensor:
         return _auc_compute(self.precision, self.recall, reorder=True)
 
 
@@ -103,9 +104,9 @@ class CSINeighborood(Metric):
         if torch.cuda.is_available():
             self._device = torch.device("cuda")
 
-        self.true_positives: torch.Tensor
-        self.false_positives: torch.Tensor
-        self.false_negatives: torch.Tensor
+        self.true_positives: Tensor
+        self.false_positives: Tensor
+        self.false_negatives: Tensor
         self.add_state(
             "true_positives",
             default=torch.zeros(self.num_classes).to(device=self.device),
@@ -122,7 +123,7 @@ class CSINeighborood(Metric):
             dist_reduce_fx="sum",
         )
 
-    def binary_dilation_(self, input_tensor: torch.Tensor) -> torch.Tensor:
+    def binary_dilation_(self, input_tensor: Tensor) -> Tensor:
         """
         Performs IN_PLACE binary dilation of input_tensor Tensor.
         input_tensor is assumed to be an implicit single channel tensor of shape (MINIBATCH, W, H).
@@ -146,18 +147,18 @@ class CSINeighborood(Metric):
         output_tensor.squeeze_(1)
         return output_tensor
 
-    def update(self, preds: torch.Tensor, targets: torch.Tensor) -> None:
+    def update(self, preds: Tensor, targets: Tensor) -> None:
         """
-        preds and targets are torch.Tensors of shape (H, w) or (B,C,H,W).
+        preds and targets are Tensors of shape (H, w) or (B,C,H,W).
         If multiclass, takes int value in [0, nb_output_channels] interval.
         """
 
         def compute_sub_results(
-            preds: torch.Tensor, targets: torch.Tensor
+            preds: Tensor, targets: Tensor
         ) -> tuple[
-            torch.Tensor,
-            torch.Tensor,
-            torch.Tensor,
+            Tensor,
+            Tensor,
+            Tensor,
         ]:
             exp_targets = targets.type(torch.FloatTensor.dtype).to(device=self.device)
             targets_extend = self.binary_dilation_(exp_targets)
@@ -201,7 +202,7 @@ class CSINeighborood(Metric):
             self.false_positives[channel] += fp
             self.false_negatives[channel] += fn
 
-    def compute(self) -> torch.Tensor:
+    def compute(self) -> Tensor:
         csi = self.true_positives / (
             self.true_positives + self.false_negatives + self.false_positives
         )

--- a/mfai/torch/models/__init__.py
+++ b/mfai/torch/models/__init__.py
@@ -36,7 +36,7 @@ autopad_nn_architectures = {
 
 pangu_nn_architectures = set()
 for obj in all_nn_architectures:
-    if hasattr(obj, 'model_type'):
+    if hasattr(obj, "model_type"):
         if obj.model_type == ModelType.PANGU:
             pangu_nn_architectures.add(obj)
 

--- a/mfai/torch/models/base.py
+++ b/mfai/torch/models/base.py
@@ -5,8 +5,7 @@ Interface contract for our models.
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Tuple
-from torch import Size
-from torch import nn
+from torch import Tensor, Size, nn
 import torch
 
 from mfai.torch.padding import pad_batch, undo_padding
@@ -134,18 +133,16 @@ class AutoPaddingModel(ABC):
                                 shape that fits the model, otherwise it will be None.
         """
 
-    def _maybe_padding(
-        self, data_tensor: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Size]:
+    def _maybe_padding(self, data_tensor: Tensor) -> tuple[Tensor, torch.Size]:
         """Performs an optional padding to ensure that the data tensor can be fed
             to the underlying model. Padding will happen only if
             autopadding was enabled via the settings.
 
         Args:
-            data_tensor (torch.Tensor): the input data to be potentially padded.
+            data_tensor (Tensor): the input data to be potentially padded.
 
         Returns:
-            tuple[torch.Tensor, torch.Size]: the padded tensor, where the original data is found in the center,
+            tuple[Tensor, torch.Size]: the padded tensor, where the original data is found in the center,
             and the old size. If padding not possible or the shape is already fine,
             the data is returned untouched with it's old shape, which is unchanged.
         """
@@ -165,19 +162,19 @@ class AutoPaddingModel(ABC):
 
     def _maybe_unpadding(
         self,
-        data_tensor: torch.Tensor,
+        data_tensor: Tensor,
         old_shape: torch.Size,
-    ) -> torch.Tensor:
+    ) -> Tensor:
         """Potentially removes the padding previously added to the given tensor. This action
            is only carried out if autopadding was enabled via the settings.
 
         Args:
-            data_tensor (torch.Tensor): The data tensor from which padding is to be removed.
+            data_tensor (Tensor): The data tensor from which padding is to be removed.
             old_shape (torch.Size): The previous shape of the data tensor. It can either be
             [W,H] or [W,H,D] for 2D and 3D data respectively. old_shape is returned by self._maybe_padding.
 
         Returns:
-            torch.Tensor: The data tensor with the padding removed, or untouched if already at the right shape.
+            Tensor: The data tensor with the padding removed, or untouched if already at the right shape.
         """
         if self.settings.autopad_enabled:
             return undo_padding(data_tensor, old_shape=old_shape)

--- a/mfai/torch/models/clip.py
+++ b/mfai/torch/models/clip.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Tuple, Union
 
 import torch
+from torch import Tensor
 
 import torch.nn as nn
 from dataclasses_json import dataclass_json
@@ -49,12 +50,12 @@ class Clip(nn.Module):
         )
         nn.init.normal_(self.text_projection, std=self.text_encoder.emb_dim**-0.5)
         self.temperature = nn.Parameter(
-            torch.ones([]) * torch.log(torch.Tensor([settings.init_temperature]))
+            torch.ones([]) * torch.log(Tensor([settings.init_temperature]))
         )
 
     def forward(
-        self, text_tokens: torch.Tensor, image_input: NamedTensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        self, text_tokens: Tensor, image_input: NamedTensor
+    ) -> Tuple[Tensor, Tensor]:
         text_tokens = text_tokens[
             :, -self.text_encoder.context_length :
         ]  # Keep only the last context_length tokens

--- a/mfai/torch/models/half_unet.py
+++ b/mfai/torch/models/half_unet.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, Sequence
 
 import torch
 from dataclasses_json import dataclass_json
-from torch import nn
+from torch import Tensor, nn
 
 from mfai.torch.models.base import AutoPaddingModel, BaseModel, ModelType
 from mfai.torch.models.utils import AbsolutePosEmdebding
@@ -55,7 +55,7 @@ class GhostModule(nn.Module):
         self.bn = nn.BatchNorm2d(num_features=out_channels)
         self.relu = nn.ReLU(inplace=True)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         x = self.conv(x)
         x2 = self.sepconv(x)
         x = torch.cat([x, x2], dim=1)
@@ -66,7 +66,7 @@ class GhostModule(nn.Module):
 class HalfUNet(BaseModel, AutoPaddingModel):
     settings_kls = HalfUNetSettings
     onnx_supported: bool = True
-    supported_num_spatial_dims: tuple[int,...] = (2,)
+    supported_num_spatial_dims: tuple[int, ...] = (2,)
     num_spatial_dims: int = 2
     features_last: bool = False
     model_type: ModelType = ModelType.CONVOLUTIONAL
@@ -179,7 +179,7 @@ class HalfUNet(BaseModel, AutoPaddingModel):
     def settings(self) -> HalfUNetSettings:
         return self._settings
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         x, old_shape = self._maybe_padding(data_tensor=x)
 
         enc1 = self.encoder1(x)
@@ -189,7 +189,7 @@ class HalfUNet(BaseModel, AutoPaddingModel):
         enc5 = self.encoder5(self.pool4(enc4))
 
         summed = reduce(
-            torch.Tensor.add_,
+            Tensor.add_,
             [enc1, self.up2(enc2), self.up3(enc3), self.up4(enc4), self.up5(enc5)],
             torch.zeros_like(enc1),
         )

--- a/mfai/torch/models/llms/__init__.py
+++ b/mfai/torch/models/llms/__init__.py
@@ -8,8 +8,9 @@ from dataclasses import dataclass
 from typing import Union
 
 import torch
+from torch import Tensor
 from dataclasses_json import dataclass_json
-from torch import Tensor, nn
+from torch import nn
 
 from mfai.torch.models.base import ModelType
 
@@ -43,7 +44,7 @@ class GELU(nn.Module):
             * (
                 1
                 + torch.tanh(
-                    torch.sqrt(torch.tensor(2.0 / torch.pi))
+                    torch.sqrt(Tensor(2.0 / torch.pi))
                     * (x + 0.044715 * torch.pow(x, 3))
                 )
             )
@@ -346,8 +347,8 @@ class MultiHeadAttentionPySDPALlama2(nn.Module):
     Mutli Head Attention using Pytorch's scaled_dot_product_attention
     """
 
-    cos: torch.Tensor
-    sin: torch.Tensor
+    cos: Tensor
+    sin: Tensor
 
     def __init__(
         self,

--- a/mfai/torch/models/llms/__init__.py
+++ b/mfai/torch/models/llms/__init__.py
@@ -44,7 +44,7 @@ class GELU(nn.Module):
             * (
                 1
                 + torch.tanh(
-                    torch.sqrt(Tensor(2.0 / torch.pi))
+                    torch.sqrt(torch.tensor(2.0 / torch.pi))
                     * (x + 0.044715 * torch.pow(x, 3))
                 )
             )

--- a/mfai/torch/models/nlam/__init__.py
+++ b/mfai/torch/models/nlam/__init__.py
@@ -394,7 +394,7 @@ class BaseHiGraphModel(BaseGraphModel):
         self.N_mesh_levels = [
             mesh_feat.shape[0] for mesh_feat in self.mesh_static_features
         ]  # Needs as python list for later
-        # N_mesh_levels_torch = Tensor(self.N_mesh_levels)
+        # N_mesh_levels_torch = torch.tensor(self.N_mesh_levels)
 
         # Print some useful info
         print("Loaded hierachical graph with structure:")

--- a/mfai/torch/models/nlam/__init__.py
+++ b/mfai/torch/models/nlam/__init__.py
@@ -10,7 +10,7 @@ import torch
 import torch_geometric as pyg
 from dataclasses_json import dataclass_json
 from mfai.torch.models.base import BaseModel, ModelType
-from torch import nn
+from torch import Tensor, nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import offload_wrapper
 
 from mfai.torch.models.utils import expand_to_batch
@@ -193,7 +193,7 @@ class BaseGraphModel(BaseModel):
     features_last: bool = True
 
     @classmethod
-    def rank_zero_setup(cls, settings: GraphLamSettings, meshgrid: torch.Tensor):
+    def rank_zero_setup(cls, settings: GraphLamSettings, meshgrid: Tensor):
         """
         This is a static method to allow multi-GPU
         trainig frameworks to call this method once
@@ -229,7 +229,7 @@ class BaseGraphModel(BaseModel):
             )
         for name, attr_value in graph_ldict.items():
             # Make BufferLists module members and register tensors as buffers
-            if isinstance(attr_value, torch.Tensor):
+            if isinstance(attr_value, Tensor):
                 print(f"Registering buffer {name}")
                 self.register_buffer(name, attr_value, persistent=False)
             else:
@@ -338,8 +338,8 @@ class BaseGraphModel(BaseModel):
 
     def forward(
         self,
-        x: torch.tensor,
-    ) -> torch.tensor:
+        x: Tensor,
+    ) -> Tensor:
         """
         Step state one step ahead using prediction model, X_{t-1}, X_t -> X_t+1
         prev_state: (B, N_grid, feature_dim), X_t
@@ -394,7 +394,7 @@ class BaseHiGraphModel(BaseGraphModel):
         self.N_mesh_levels = [
             mesh_feat.shape[0] for mesh_feat in self.mesh_static_features
         ]  # Needs as python list for later
-        # N_mesh_levels_torch = torch.tensor(self.N_mesh_levels)
+        # N_mesh_levels_torch = Tensor(self.N_mesh_levels)
 
         # Print some useful info
         print("Loaded hierachical graph with structure:")

--- a/mfai/torch/models/nlam/create_mesh.py
+++ b/mfai/torch/models/nlam/create_mesh.py
@@ -305,7 +305,7 @@ def build_graph_for_grid(
     """
 
     xy = grid_xy.numpy()
-    grid_xy = Tensor(xy)
+    grid_xy = torch.tensor(xy)
     pos_max = torch.max(torch.abs(grid_xy))
 
     # graph geometry

--- a/mfai/torch/models/nlam/create_mesh.py
+++ b/mfai/torch/models/nlam/create_mesh.py
@@ -5,6 +5,7 @@ import networkx
 import numpy as np
 import scipy.spatial
 import torch
+from torch import Tensor
 import torch_geometric as pyg
 from torch_geometric.utils.convert import from_networkx
 
@@ -290,7 +291,7 @@ def monolevel_mesh(G, nx, plot):
 
 
 def build_graph_for_grid(
-    grid_xy: torch.Tensor,
+    grid_xy: Tensor,
     cache_dir_path: str,
     plot: bool = False,
     levels: int = None,
@@ -304,7 +305,7 @@ def build_graph_for_grid(
     """
 
     xy = grid_xy.numpy()
-    grid_xy = torch.tensor(xy)
+    grid_xy = Tensor(xy)
     pos_max = torch.max(torch.abs(grid_xy))
 
     # graph geometry

--- a/mfai/torch/models/pangu.py
+++ b/mfai/torch/models/pangu.py
@@ -26,7 +26,7 @@ from torch.nn import (
     LayerNorm,
     Softmax,
     ConstantPad3d,
-    ConstantPad2d
+    ConstantPad2d,
 )
 from torch import nn, Tensor
 from torch.utils.checkpoint import checkpoint
@@ -47,18 +47,19 @@ def define_3d_earth_position_index(window_size: Tuple[int, int, int]) -> Tensor:
     Returns:
         Tensor: index
     """
-    assert len(window_size) == 3, "Data must be 3D, but window has {}" \
-        "dimension(s)".format(len(window_size))
+    assert len(window_size) == 3, (
+        "Data must be 3D, but window has {}" "dimension(s)".format(len(window_size))
+    )
 
     # Index in the pressure level of query matrix
     coords_zi = torch.arange(window_size[0])
     # Index in the pressure level of key matrix
-    coords_zj = -torch.arange(window_size[0])*window_size[0]
+    coords_zj = -torch.arange(window_size[0]) * window_size[0]
 
     # Index in the latitude of query matrix
     coords_hi = torch.arange(window_size[1])
     # Index in the latitude of key matrix
-    coords_hj = -torch.arange(window_size[1])*window_size[1]
+    coords_hj = -torch.arange(window_size[1]) * window_size[1]
 
     # Index in the longitude of the key-value pair
     coords_w = torch.arange(window_size[2])
@@ -66,7 +67,7 @@ def define_3d_earth_position_index(window_size: Tuple[int, int, int]) -> Tensor:
     # Change the order of the index to calculate the index in total
     coords_1 = torch.stack(torch.meshgrid([coords_zi, coords_hi, coords_w]))
     coords_2 = torch.stack(torch.meshgrid([coords_zj, coords_hj, coords_w]))
-    coords_flatten_1 = torch.flatten(coords_1, start_dim=1) 
+    coords_flatten_1 = torch.flatten(coords_1, start_dim=1)
     coords_flatten_2 = torch.flatten(coords_2, start_dim=1)
     coords = coords_flatten_1[:, :, None] - coords_flatten_2[:, None, :]
     coords = coords.permute(1, 2, 0).contiguous()
@@ -74,7 +75,7 @@ def define_3d_earth_position_index(window_size: Tuple[int, int, int]) -> Tensor:
     # Shift the index for each dimension to start from 0
     coords[:, :, 2] += window_size[2] - 1
     coords[:, :, 1] *= 2 * window_size[2] - 1
-    coords[:, :, 0] *= (2 * window_size[2] - 1)*window_size[1]*window_size[1]
+    coords[:, :, 0] *= (2 * window_size[2] - 1) * window_size[1] * window_size[1]
 
     # Sum up the indexes in three dimensions
     position_index = coords.sum(dim=-1)
@@ -86,11 +87,11 @@ def define_3d_earth_position_index(window_size: Tuple[int, int, int]) -> Tensor:
 
 
 def generate_3d_attention_mask(
-        x: Tensor,
-        window_size: Tuple[int, int, int],
-        shift_size: Tuple[int, ...],
-        lam: bool = False
-        ) -> Tensor:
+    x: Tensor,
+    window_size: Tuple[int, int, int],
+    shift_size: Tuple[int, ...],
+    lam: bool = False,
+) -> Tensor:
     """Method to generate attention mask for sliding window attention in the context of 3D data.
     Based on https://pytorch.org/vision/main/_modules/torchvision/models/swin_transformer.html#swin_s
 
@@ -104,10 +105,16 @@ def generate_3d_attention_mask(
     """
     assert x.dim() == 5, "Data must be 3D, but has {} dimension(s)".format(x.dim())
     _, pad_z, pad_h, pad_w, _ = x.shape
-    assert pad_z % window_size[0] == 0 and pad_h % window_size[
-        1] == 0 and pad_w % window_size[2] == 0, "the data size must divisible by window size"
-    assert window_size[0] % shift_size[0] == 0 and window_size[1] % shift_size[
-        1] == 0 and window_size[2] % shift_size[2] == 0, "the window size must divisible by shift size"
+    assert (
+        pad_z % window_size[0] == 0
+        and pad_h % window_size[1] == 0
+        and pad_w % window_size[2] == 0
+    ), "the data size must divisible by window size"
+    assert (
+        window_size[0] % shift_size[0] == 0
+        and window_size[1] % shift_size[1] == 0
+        and window_size[2] % shift_size[2] == 0
+    ), "the window size must divisible by shift size"
 
     # Create the attention mask from the data to have same type and device
     attention_mask = x.new_zeros((pad_z, pad_h, pad_w))
@@ -123,19 +130,27 @@ def generate_3d_attention_mask(
     for z in z_slices:
         for h in h_slices:
             for w in w_slices:
-                attention_mask[z[0]:z[1], h[0]:h[1], w[0]:w[1]] = count
+                attention_mask[z[0] : z[1], h[0] : h[1], w[0] : w[1]] = count
                 count += 1
 
-    attention_mask = attention_mask.reshape(pad_z // window_size[0], window_size[0],
-                                            pad_h // window_size[1], window_size[1],
-                                            pad_w // window_size[2], window_size[2]
-                                            )
+    attention_mask = attention_mask.reshape(
+        pad_z // window_size[0],
+        window_size[0],
+        pad_h // window_size[1],
+        window_size[1],
+        pad_w // window_size[2],
+        window_size[2],
+    )
     num_windows = (
-        pad_z // window_size[0]) * (pad_h // window_size[1]) * (pad_w // window_size[2])
-    attention_mask = torch.permute(
-        attention_mask, (0, 2, 4, 1, 3, 5)).reshape(num_windows, -1)
+        (pad_z // window_size[0])
+        * (pad_h // window_size[1])
+        * (pad_w // window_size[2])
+    )
+    attention_mask = torch.permute(attention_mask, (0, 2, 4, 1, 3, 5)).reshape(
+        num_windows, -1
+    )
     attention_mask = attention_mask.unsqueeze(1) - attention_mask.unsqueeze(2)
-    attention_mask.masked_fill_(attention_mask != 0, -100.)
+    attention_mask.masked_fill_(attention_mask != 0, -100.0)
     return attention_mask
 
 
@@ -152,7 +167,7 @@ class PanguWeatherSettings:
     plevels: int = 13
     static_length: int = 3
     window_size: Tuple[int, int, int] = (2, 6, 12)
-    dropout_rate: float = 0.
+    dropout_rate: float = 0.0
     checkpoint_activation: bool = False
     lam: bool = False
 
@@ -162,6 +177,7 @@ class PanguWeather(BaseModel):
     PanguWeather network as described in http://arxiv.org/abs/2211.02556 and https://www.nature.com/articles/s41586-023-06185-3.
     This implementation follows the official pseudo code here: https://github.com/198808xc/Pangu-Weather
     """
+
     onnx_supported: bool = False
     supported_num_spatial_dims: Tuple = (2,)
     settings_kls = PanguWeatherSettings
@@ -170,11 +186,11 @@ class PanguWeather(BaseModel):
     register: bool = True
 
     def __init__(
-            self, 
-            in_channels: int,
-            out_channels: int,
-            input_shape: Tuple[int, ...],
-            settings: PanguWeatherSettings = PanguWeatherSettings(),
+        self,
+        in_channels: int,
+        out_channels: int,
+        input_shape: Tuple[int, ...],
+        settings: PanguWeatherSettings = PanguWeatherSettings(),
     ) -> None:
         """
         Args:
@@ -210,18 +226,25 @@ class PanguWeather(BaseModel):
         self.plevel_patch_size = settings.plevel_patch_size
 
         # Compute surface size and plevel size. Needed to compute the size of earth specific bias
-        self.surface_channels = settings.surface_variables + settings.static_length 
+        self.surface_channels = settings.surface_variables + settings.static_length
         surface_size = torch.Size((self.surface_channels, latitude, longitude))
-        plevel_size = torch.Size((settings.plevel_variables, settings.plevels, latitude, longitude))
-        
+        plevel_size = torch.Size(
+            (settings.plevel_variables, settings.plevels, latitude, longitude)
+        )
+
         # Drop path rate is linearly increased as the depth increases
         drop_path_list = torch.linspace(0, 0.2, 8)
 
         # Patch embedding
         token_size = settings.token_size
-        self.embedding_layer = PatchEmbedding(token_size, self.plevel_patch_size, plevel_size=plevel_size, surface_size=surface_size)
+        self.embedding_layer = PatchEmbedding(
+            token_size,
+            self.plevel_patch_size,
+            plevel_size=plevel_size,
+            surface_size=surface_size,
+        )
         embedding_size = self.embedding_layer.embedding_size
-        
+
         # Upsample and downsample
         self.downsample = DownSample(embedding_size, token_size)
         downsampled_size = self.downsample.downsampled_size
@@ -231,16 +254,16 @@ class PanguWeather(BaseModel):
         layer_depth = settings.layer_depth
         num_heads = settings.num_heads
         self.layer1 = EarthSpecificLayer(
-            depth=layer_depth[0], 
-            data_size=embedding_size, 
-            dim=token_size, 
-            drop_path_ratio_list=drop_path_list[:2], 
+            depth=layer_depth[0],
+            data_size=embedding_size,
+            dim=token_size,
+            drop_path_ratio_list=drop_path_list[:2],
             num_heads=num_heads[0],
             window_size=settings.window_size,
             dropout_rate=settings.dropout_rate,
             checkpoint_activation=settings.checkpoint_activation,
             lam=settings.lam,
-            )
+        )
         self.layer2 = EarthSpecificLayer(
             depth=layer_depth[1],
             data_size=downsampled_size,
@@ -251,7 +274,7 @@ class PanguWeather(BaseModel):
             dropout_rate=settings.dropout_rate,
             checkpoint_activation=settings.checkpoint_activation,
             lam=settings.lam,
-            )
+        )
         self.layer3 = EarthSpecificLayer(
             depth=layer_depth[1],
             data_size=downsampled_size,
@@ -262,7 +285,7 @@ class PanguWeather(BaseModel):
             dropout_rate=settings.dropout_rate,
             checkpoint_activation=settings.checkpoint_activation,
             lam=settings.lam,
-            )
+        )
         self.layer4 = EarthSpecificLayer(
             depth=layer_depth[0],
             data_size=embedding_size,
@@ -273,7 +296,7 @@ class PanguWeather(BaseModel):
             dropout_rate=settings.dropout_rate,
             checkpoint_activation=settings.checkpoint_activation,
             lam=settings.lam,
-            )
+        )
 
         # Patch Recovery
         self._output_layer = PatchRecovery(
@@ -281,7 +304,7 @@ class PanguWeather(BaseModel):
             patch_size=self.plevel_patch_size,
             plevel_channels=settings.plevel_variables,
             surface_channels=settings.surface_variables,
-            )
+        )
 
         self.check_required_attributes()
 
@@ -292,8 +315,10 @@ class PanguWeather(BaseModel):
     @property
     def num_spatial_dims(self) -> int:
         return self.settings.spatial_dims
-    
-    def forward(self, input_plevel: Tensor, input_surface: Tensor, static_data: Tensor = None) -> Tuple[Tensor, Tensor]:
+
+    def forward(
+        self, input_plevel: Tensor, input_surface: Tensor, static_data: Tensor = None
+    ) -> Tuple[Tensor, Tensor]:
         """
         Forward pass of the PanguWeather model.
         Args:
@@ -305,10 +330,10 @@ class PanguWeather(BaseModel):
             surface_data = torch.cat([input_surface, static_data], dim=1)
         else:
             surface_data = input_surface
-                     
+
         # Embed the input fields into patches
         x, embedding_shape = self.embedding_layer(input_plevel, surface_data)
-        
+
         # Encoder, composed of two layers
         x = self.layer1(x, embedding_shape)
 
@@ -320,29 +345,46 @@ class PanguWeather(BaseModel):
 
         # Layer 2, shape (8, 91, 180, 2C), C = 192 as in the original paper in the case of vanilla Pangu
         x = self.layer2(x, downsampled_shape)
-        
+
         # Decoder, composed of two layers
         # Layer 3, shape (8, 91, 180, 2C), C = 192 as in the original paper in the case of vanilla Pangu
         x = self.layer3(x, downsampled_shape)
-        
+
         # Upsample from (8, 91, 180) to (8, 181, 360)
         x = self.upsample(x, embedding_shape)
 
         # Layer 4, shape (8, 181, 360, 2C), C = 192 as in the original paper in the case of vanilla Pangu
         x = self.layer4(x, embedding_shape)
-       
+
         # Skip connect, in last dimension(C from 192 to 384) in the case of vanilla Pangu
         x = torch.cat([x, skip], dim=-1)
 
         # Recover the output fields from patches
-        output_plevel, output_surface = self._output_layer(
-            x, embedding_shape)
+        output_plevel, output_surface = self._output_layer(x, embedding_shape)
 
         # Crop the output to remove zero-paddings
         padded_z, padded_h, padded_w = output_plevel.shape[2:5]
-        padding_left, padding_right, padding_top, padding_bottom, padding_front, padding_back = self.embedding_layer.pad_plevel_data.padding
-        output_plevel = output_plevel[:, :, padding_front:padded_z-padding_back, padding_top:padded_h-padding_bottom, padding_left:padded_w-padding_right]
-        output_surface = output_surface[:, :, padding_top:padded_h-padding_bottom, padding_left:padded_w-padding_right]
+        (
+            padding_left,
+            padding_right,
+            padding_top,
+            padding_bottom,
+            padding_front,
+            padding_back,
+        ) = self.embedding_layer.pad_plevel_data.padding
+        output_plevel = output_plevel[
+            :,
+            :,
+            padding_front : padded_z - padding_back,
+            padding_top : padded_h - padding_bottom,
+            padding_left : padded_w - padding_right,
+        ]
+        output_surface = output_surface[
+            :,
+            :,
+            padding_top : padded_h - padding_bottom,
+            padding_left : padded_w - padding_right,
+        ]
 
         return output_plevel, output_surface
 
@@ -356,24 +398,60 @@ class CustomPad3d(ConstantPad3d):
         value (float, optional): padding value. Defaults to 0.
     """
 
-    def __init__(self, data_size: torch.Size, patch_size: Tuple[int, int, int], value: float = 0.) -> None:
+    def __init__(
+        self,
+        data_size: torch.Size,
+        patch_size: Tuple[int, int, int],
+        value: float = 0.0,
+    ) -> None:
         # Compute paddings, starts from the last dim and goes backward
-        assert len(data_size) == 3, "This padding class is for 3d data, but data has {} dimension(s)".format(
-            len(data_size))
-        assert len(patch_size) == 3, "Patch should be 3d, but has {} dimension(s)".format(
-            len(patch_size))
-        padding_lon = patch_size[-1] - (data_size[-1] % patch_size[-1]) if (data_size[-1] % patch_size[-1]) > 0 else 0
+        assert (
+            len(data_size) == 3
+        ), "This padding class is for 3d data, but data has {} dimension(s)".format(
+            len(data_size)
+        )
+        assert (
+            len(patch_size) == 3
+        ), "Patch should be 3d, but has {} dimension(s)".format(len(patch_size))
+        padding_lon = (
+            patch_size[-1] - (data_size[-1] % patch_size[-1])
+            if (data_size[-1] % patch_size[-1]) > 0
+            else 0
+        )
         padding_left = padding_lon // 2
         padding_right = padding_lon - padding_left
-        padding_lat = patch_size[-2] - (data_size[-2] % patch_size[-2]) if (data_size[-2] % patch_size[-2]) > 0 else 0
+        padding_lat = (
+            patch_size[-2] - (data_size[-2] % patch_size[-2])
+            if (data_size[-2] % patch_size[-2]) > 0
+            else 0
+        )
         padding_top = padding_lat // 2
         padding_bottom = padding_lat - padding_top
-        padding_level = patch_size[-3] - (data_size[-3] % patch_size[-3]) if (data_size[-3] % patch_size[-3]) > 0 else 0
-        padding_front = padding_level // 2 
+        padding_level = (
+            patch_size[-3] - (data_size[-3] % patch_size[-3])
+            if (data_size[-3] % patch_size[-3]) > 0
+            else 0
+        )
+        padding_front = padding_level // 2
         padding_back = padding_level - padding_front
-        super().__init__(padding=(padding_left, padding_right, padding_top,
-                                  padding_bottom, padding_front, padding_back), value=value)
-        self.padded_size = torch.Size([data_size[0] + padding_level, data_size[1] + padding_lat, data_size[2] + padding_lon])
+        super().__init__(
+            padding=(
+                padding_left,
+                padding_right,
+                padding_top,
+                padding_bottom,
+                padding_front,
+                padding_back,
+            ),
+            value=value,
+        )
+        self.padded_size = torch.Size(
+            [
+                data_size[0] + padding_level,
+                data_size[1] + padding_lat,
+                data_size[2] + padding_lon,
+            ]
+        )
 
 
 class CustomPad2d(ConstantPad2d):
@@ -385,25 +463,43 @@ class CustomPad2d(ConstantPad2d):
         value (float, optional): padding value. Defaults to 0.
     """
 
-    def __init__(self, data_size: torch.Size, patch_size: Tuple[int, int], value: float = 0.) -> None:
+    def __init__(
+        self, data_size: torch.Size, patch_size: Tuple[int, int], value: float = 0.0
+    ) -> None:
         # Compute paddings, starts from the last dim and goes backward
-        assert len(data_size) == 2, "This padding class is for 2d data, but data has {} dimension(s)".format(
-            len(data_size))
-        assert len(patch_size) == 2, "Patch should be 2d, but has {} dimension(s)".format(
-            len(patch_size))
-        padding_lon = patch_size[-1] - (data_size[-1] % patch_size[-1]) if (data_size[-1] % patch_size[-1]) > 0 else 0
+        assert (
+            len(data_size) == 2
+        ), "This padding class is for 2d data, but data has {} dimension(s)".format(
+            len(data_size)
+        )
+        assert (
+            len(patch_size) == 2
+        ), "Patch should be 2d, but has {} dimension(s)".format(len(patch_size))
+        padding_lon = (
+            patch_size[-1] - (data_size[-1] % patch_size[-1])
+            if (data_size[-1] % patch_size[-1]) > 0
+            else 0
+        )
         padding_left = padding_lon // 2
         padding_right = padding_lon - padding_left
-        padding_lat = patch_size[-2] - (data_size[-2] % patch_size[-2]) if (data_size[-2] % patch_size[-2]) > 0 else 0
+        padding_lat = (
+            patch_size[-2] - (data_size[-2] % patch_size[-2])
+            if (data_size[-2] % patch_size[-2]) > 0
+            else 0
+        )
         padding_top = padding_lat // 2
         padding_bottom = padding_lat - padding_top
-        super().__init__(padding=(padding_left, padding_right,
-                                  padding_top, padding_bottom), value=value)
-        self.padded_size = torch.Size([data_size[0] + padding_lat, data_size[1] + padding_lon])
+        super().__init__(
+            padding=(padding_left, padding_right, padding_top, padding_bottom),
+            value=value,
+        )
+        self.padded_size = torch.Size(
+            [data_size[0] + padding_lat, data_size[1] + padding_lon]
+        )
 
 
 class PatchEmbedding(nn.Module):
-    """Patch embedding operation. Apply a linear projection for patch_size[0]*patch_size[1]*patch_size[2] patches, 
+    """Patch embedding operation. Apply a linear projection for patch_size[0]*patch_size[1]*patch_size[2] patches,
         patch_size = (2, 4, 4) in the original paper
 
     Args:
@@ -413,14 +509,28 @@ class PatchEmbedding(nn.Module):
         surface_size (torch.Size): surface data size
     """
 
-    def __init__(self, c_dim: int, patch_size: Tuple[int, int, int], plevel_size: torch.Size, surface_size: torch.Size) -> None:
+    def __init__(
+        self,
+        c_dim: int,
+        patch_size: Tuple[int, int, int],
+        plevel_size: torch.Size,
+        surface_size: torch.Size,
+    ) -> None:
         super().__init__()
-        
+
         # Here we use convolution to partition data into cubes
-        self.conv_surface = Conv2d(in_channels=surface_size[0], out_channels=c_dim,
-                                   kernel_size=patch_size[1:], stride=patch_size[1:])
+        self.conv_surface = Conv2d(
+            in_channels=surface_size[0],
+            out_channels=c_dim,
+            kernel_size=patch_size[1:],
+            stride=patch_size[1:],
+        )
         self.conv_plevel = Conv3d(
-            in_channels=plevel_size[0], out_channels=c_dim, kernel_size=patch_size, stride=patch_size)
+            in_channels=plevel_size[0],
+            out_channels=c_dim,
+            kernel_size=patch_size,
+            stride=patch_size,
+        )
 
         # init padding
         self.pad_plevel_data = CustomPad3d(plevel_size[-3:], patch_size)
@@ -428,11 +538,16 @@ class PatchEmbedding(nn.Module):
 
         # Compute output size
         plevel_padded_size = self.pad_plevel_data.padded_size
-        embedding_size = [plevel_dim // patch_dim for plevel_dim, patch_dim in zip(plevel_padded_size, patch_size)]
-        embedding_size[0] += 1 
+        embedding_size = [
+            plevel_dim // patch_dim
+            for plevel_dim, patch_dim in zip(plevel_padded_size, patch_size)
+        ]
+        embedding_size[0] += 1
         self.embedding_size = torch.Size(embedding_size)
 
-    def forward(self, input_plevel: Tensor, input_surface: Tensor) -> Tuple[Tensor, torch.Size]:
+    def forward(
+        self, input_plevel: Tensor, input_surface: Tensor
+    ) -> Tuple[Tensor, torch.Size]:
         # Zero-pad the input
         plevel_data = self.pad_plevel_data(input_plevel)
         surface_data = self.pad_surface_data(input_surface)
@@ -443,7 +558,7 @@ class PatchEmbedding(nn.Module):
 
         # Concatenate the input in the pressure level, i.e., in Z dimension
         x = torch.cat([plevel_tokens, surface_tokens.unsqueeze(2)], dim=2)
-        
+
         # Reshape x for calculation of linear projections
         x = x.permute((0, 2, 3, 4, 1))
         embedding_shape = x.shape
@@ -462,18 +577,33 @@ class PatchRecovery(nn.Module):
         surface_channels (int, optional): surface data channel size
     """
 
-    def __init__(self, dim: int, patch_size: Tuple[int, int, int], plevel_channels: int = 5, surface_channels: int = 4) -> None:
+    def __init__(
+        self,
+        dim: int,
+        patch_size: Tuple[int, int, int],
+        plevel_channels: int = 5,
+        surface_channels: int = 4,
+    ) -> None:
         super().__init__()
         # Hear we use two transposed convolutions to recover data
         self.conv_surface = ConvTranspose2d(
-            in_channels=dim, out_channels=surface_channels, kernel_size=patch_size[1:], stride=patch_size[1:])
+            in_channels=dim,
+            out_channels=surface_channels,
+            kernel_size=patch_size[1:],
+            stride=patch_size[1:],
+        )
         self.conv = ConvTranspose3d(
-            in_channels=dim, out_channels=plevel_channels, kernel_size=patch_size, stride=patch_size)
-        
-        
+            in_channels=dim,
+            out_channels=plevel_channels,
+            kernel_size=patch_size,
+            stride=patch_size,
+        )
+
     def forward(self, x: Tensor, embedding_shape: torch.Size) -> Tuple[Tensor, Tensor]:
         # Reshape x back to three dimensions
-        x = x.reshape(x.shape[0], embedding_shape[1], embedding_shape[2], embedding_shape[3], -1)
+        x = x.reshape(
+            x.shape[0], embedding_shape[1], embedding_shape[2], embedding_shape[3], -1
+        )
         x = x.permute(0, 4, 1, 2, 3)
 
         # Call the transposed convolution
@@ -495,13 +625,17 @@ class DownSample(nn.Module):
     def __init__(self, data_size: torch.Size, dim: int) -> None:
         super().__init__()
         # A linear function and a layer normalization
-        self.linear = Linear(in_features=4*dim, out_features=2*dim, bias=False)
-        self.norm = LayerNorm(normalized_shape=4*dim)
+        self.linear = Linear(in_features=4 * dim, out_features=2 * dim, bias=False)
+        self.norm = LayerNorm(normalized_shape=4 * dim)
         self.pad = CustomPad3d(data_size[-3:], (1, 2, 2))
         padded_size = self.pad.padded_size
-        self.downsampled_size = torch.Size([padded_size[0], padded_size[1] // 2, padded_size[2] // 2])
+        self.downsampled_size = torch.Size(
+            [padded_size[0], padded_size[1] // 2, padded_size[2] // 2]
+        )
 
-    def forward(self, x: Tensor, embedding_shape: torch.Size) -> Tuple[Tensor, torch.Size]:
+    def forward(
+        self, x: Tensor, embedding_shape: torch.Size
+    ) -> Tuple[Tensor, torch.Size]:
         # Reshape x to three dimensions for downsampling
         x = x.reshape(shape=embedding_shape)
 
@@ -513,18 +647,18 @@ class DownSample(nn.Module):
         # Reorganize x to reduce the resolution: simply change the order and downsample from (8, 182, 360) to (8, 91, 180)
         Z, H, W = x.shape[1:4]
         # Reshape x to facilitate downsampling
-        x = x.reshape(shape=(x.shape[0], Z, H//2, 2, W//2, 2, x.shape[-1]))
+        x = x.reshape(shape=(x.shape[0], Z, H // 2, 2, W // 2, 2, x.shape[-1]))
         # Change the order of x
         x = x.permute((0, 1, 2, 4, 3, 5, 6))
         # Reshape to get a tensor of resolution (8, 91, 180) -> 4 times less tokens of 4 times bigger size
-        x = x.reshape(shape=(x.shape[0], Z*(H//2)*(W//2), -1))
+        x = x.reshape(shape=(x.shape[0], Z * (H // 2) * (W // 2), -1))
 
         # Call the layer normalization
         x = self.norm(x)
 
         # Decrease the size of the tokens to reduce computation cost
         x = self.linear(x)
-        return x, torch.Size([x.shape[0], Z, (H//2), (W//2), x.shape[-1]])
+        return x, torch.Size([x.shape[0], Z, (H // 2), (W // 2), x.shape[-1]])
 
 
 class UpSample(nn.Module):
@@ -537,7 +671,7 @@ class UpSample(nn.Module):
         """
         super().__init__()
         # Linear layers without bias to increase channels of the data
-        self.linear1 = Linear(input_dim, output_dim*4, bias=False)
+        self.linear1 = Linear(input_dim, output_dim * 4, bias=False)
 
         # Linear layers without bias to mix the data up
         self.linear2 = Linear(output_dim, output_dim, bias=False)
@@ -546,8 +680,9 @@ class UpSample(nn.Module):
         self.norm = LayerNorm(output_dim)
 
     def forward(self, x: Tensor, embedding_shape: torch.Size) -> Tensor:
-        assert x.shape[-1] % 4 == 0, "The token size must be divisible by 4, but is {}".format(
-            x.shape[-1])
+        assert (
+            x.shape[-1] % 4 == 0
+        ), "The token size must be divisible by 4, but is {}".format(x.shape[-1])
         # Z, H, W represent the desired output shape
         h_d = embedding_shape[2] // 2 + embedding_shape[2] % 2
         w_d = embedding_shape[3] // 2 + embedding_shape[3] % 2
@@ -561,10 +696,10 @@ class UpSample(nn.Module):
         # Change the order of x
         x = x.permute((0, 1, 2, 4, 3, 5, 6))
         # Reshape to get Tensor with a resolution of (8, 182, 360)
-        x = x.reshape(shape=(x.shape[0], embedding_shape[1], h_d*2, w_d*2, -1))
+        x = x.reshape(shape=(x.shape[0], embedding_shape[1], h_d * 2, w_d * 2, -1))
 
         # Crop the output to the input shape of the network
-        x = x[:, :, :embedding_shape[2], :embedding_shape[3], :]
+        x = x[:, :, : embedding_shape[2], : embedding_shape[3], :]
 
         # Reshape x back
         x = x.reshape(shape=(x.shape[0], -1, x.shape[-1]))
@@ -592,24 +727,33 @@ class EarthSpecificLayer(nn.Module):
         lam (bool, optional): see EarthSpecificBlock
     """
 
-
-    def __init__(self, depth: int, data_size: torch.Size, dim: int, drop_path_ratio_list: Tensor, num_heads: int, window_size: Tuple[int, int, int], 
-                 dropout_rate: float, checkpoint_activation: bool, lam: bool) -> None:
-
+    def __init__(
+        self,
+        depth: int,
+        data_size: torch.Size,
+        dim: int,
+        drop_path_ratio_list: Tensor,
+        num_heads: int,
+        window_size: Tuple[int, int, int],
+        dropout_rate: float,
+        checkpoint_activation: bool,
+        lam: bool,
+    ) -> None:
         super().__init__()
         self.blocks = nn.ModuleList()
 
         # Construct basic blocks
         for i in range(depth):
-            self.blocks.append(EarthSpecificBlock(
-                data_size=data_size, 
-                dim=dim, 
-                drop_path_ratio=drop_path_ratio_list[i].item(), 
-                num_heads=num_heads, 
-                window_size=window_size, 
-                dropout_rate=dropout_rate, 
-                checkpoint_activation=checkpoint_activation, 
-                lam=lam
+            self.blocks.append(
+                EarthSpecificBlock(
+                    data_size=data_size,
+                    dim=dim,
+                    drop_path_ratio=drop_path_ratio_list[i].item(),
+                    num_heads=num_heads,
+                    window_size=window_size,
+                    dropout_rate=dropout_rate,
+                    checkpoint_activation=checkpoint_activation,
+                    lam=lam,
                 )
             )
 
@@ -619,12 +763,12 @@ class EarthSpecificLayer(nn.Module):
             if i % 2 == 0:
                 x = block(x, embedding_shape, roll=False)
             else:
-                x= block(x, embedding_shape, roll=True)
+                x = block(x, embedding_shape, roll=True)
         return x
 
 
 class EarthSpecificBlock(nn.Module):
-    """3D transformer block with Earth-Specific bias and window attention, 
+    """3D transformer block with Earth-Specific bias and window attention,
         see https://github.com/microsoft/Swin-Transformer for the official implementation of 2D window attention.
         The major difference is that we expand the dimensions to 3 and replace the relative position bias with Earth-Specific bias.
 
@@ -639,23 +783,35 @@ class EarthSpecificBlock(nn.Module):
         lam (bool, optional): whether to use the limited area attention mask. Defaults to False.
     """
 
-    def __init__(self, data_size: torch.Size, dim: int, drop_path_ratio: float, num_heads: int, window_size: Tuple[int, int, int] = (2, 6, 12), 
-                 dropout_rate: float = 0., checkpoint_activation: bool = False, lam: bool = False) -> None:
+    def __init__(
+        self,
+        data_size: torch.Size,
+        dim: int,
+        drop_path_ratio: float,
+        num_heads: int,
+        window_size: Tuple[int, int, int] = (2, 6, 12),
+        dropout_rate: float = 0.0,
+        checkpoint_activation: bool = False,
+        lam: bool = False,
+    ) -> None:
         super().__init__()
 
         self.checkpoint_activation = checkpoint_activation
         self.lam = lam
         # Define the window size of the neural network
         self.window_size = window_size
-        assert all([w_s % 2 == 0 for w_s in window_size]
-                   ), "Window size must be divisible by 2"
+        assert all(
+            [w_s % 2 == 0 for w_s in window_size]
+        ), "Window size must be divisible by 2"
         self.shift_size = tuple(w_size // 2 for w_size in window_size)
 
         # Initialize serveral operations
         self.drop_path = DropPath(drop_prob=drop_path_ratio)
         self.norm1 = LayerNorm(dim)
         self.pad3D = CustomPad3d(data_size[-3:], self.window_size)
-        self.attention = EarthAttention3D(self.pad3D.padded_size, dim, num_heads, dropout_rate, self.window_size)
+        self.attention = EarthAttention3D(
+            self.pad3D.padded_size, dim, num_heads, dropout_rate, self.window_size
+        )
         self.norm2 = LayerNorm(dim)
         self.mlp = MLP(dim, dropout_rate=dropout_rate)
 
@@ -679,41 +835,65 @@ class EarthSpecificBlock(nn.Module):
 
         if roll:
             # Roll x for half of the window for 3 dimensions
-            x = x.roll(shifts=(
-                -self.shift_size[0], -self.shift_size[1], -self.shift_size[2]), dims=(1, 2, 3))
+            x = x.roll(
+                shifts=(-self.shift_size[0], -self.shift_size[1], -self.shift_size[2]),
+                dims=(1, 2, 3),
+            )
             # Generate mask of attention masks
             # If two pixels are not adjacent, then mask the attention between them
             # Your can set the matrix element to -1000 when it is not adjacent, then add it to the attention
-            mask = generate_3d_attention_mask(x, self.window_size, self.shift_size, self.lam)
+            mask = generate_3d_attention_mask(
+                x, self.window_size, self.shift_size, self.lam
+            )
         else:
             # e.g., zero matrix when you add mask to attention
             mask = None
 
         # Reorganize data to calculate window attention
-        x_window = x.reshape(shape=(x.shape[0],
-                                    padded_z // self.window_size[0], self.window_size[0],
-                                    padded_h // self.window_size[1], self.window_size[1],
-                                    padded_w // self.window_size[2], self.window_size[2],
-                                    -1)
-                             )
+        x_window = x.reshape(
+            shape=(
+                x.shape[0],
+                padded_z // self.window_size[0],
+                self.window_size[0],
+                padded_h // self.window_size[1],
+                self.window_size[1],
+                padded_w // self.window_size[2],
+                self.window_size[2],
+                -1,
+            )
+        )
         x_window = x_window.permute((0, 1, 3, 5, 2, 4, 6, 7))
 
         # Get data stacked in 3D cubes, which will further be used to calculated attention among each cube
         x_window = x_window.reshape(
-            shape=(-1, self.window_size[0]*self.window_size[1]*self.window_size[2], C))
-        
+            shape=(
+                -1,
+                self.window_size[0] * self.window_size[1] * self.window_size[2],
+                C,
+            )
+        )
+
         # Apply 3D window attention with Earth-Specific bias
         if self.checkpoint_activation:
-            x_window = checkpoint(self.attention, x_window, mask, batch_size, use_reentrant=False)
+            x_window = checkpoint(
+                self.attention, x_window, mask, batch_size, use_reentrant=False
+            )
         else:
             x_window = self.attention(x_window, mask, batch_size)
 
         # Reorganize data to original shapes
-        x = x_window.reshape(shape=(batch_size,
-                                    padded_z // self.window_size[0], padded_h // self.window_size[1], padded_w // self.window_size[2],
-                                    self.window_size[0], self.window_size[1], self.window_size[2],
-                                    -1)
-                             )
+        x = x_window.reshape(
+            shape=(
+                batch_size,
+                padded_z // self.window_size[0],
+                padded_h // self.window_size[1],
+                padded_w // self.window_size[2],
+                self.window_size[0],
+                self.window_size[1],
+                self.window_size[2],
+                -1,
+            )
+        )
         x = x.permute((0, 1, 4, 2, 5, 3, 6, 7))
 
         # Reshape the tensor back to its original shape
@@ -722,11 +902,26 @@ class EarthSpecificBlock(nn.Module):
         if roll:
             # Roll x back for half of the window
             x = x.roll(
-                shifts=(self.shift_size[0], self.shift_size[1], self.shift_size[2]), dims=(1, 2, 3))
+                shifts=(self.shift_size[0], self.shift_size[1], self.shift_size[2]),
+                dims=(1, 2, 3),
+            )
 
         # Crop the zero-padding
-        padding_left, padding_right, padding_top, padding_bottom, padding_front, padding_back = self.pad3D.padding
-        x = x[:, padding_front:padded_z-padding_back, padding_top:padded_h-padding_bottom, padding_left:padded_w-padding_right, :]
+        (
+            padding_left,
+            padding_right,
+            padding_top,
+            padding_bottom,
+            padding_front,
+            padding_back,
+        ) = self.pad3D.padding
+        x = x[
+            :,
+            padding_front : padded_z - padding_back,
+            padding_top : padded_h - padding_bottom,
+            padding_left : padded_w - padding_right,
+            :,
+        ]
 
         # Reshape the tensor back to the input shape
         x = x.reshape(shape=(batch_size, -1, C))
@@ -738,7 +933,7 @@ class EarthSpecificBlock(nn.Module):
 
 
 class EarthAttention3D(nn.Module):
-    """3D sliding window attention with the Earth-Specific bias, 
+    """3D sliding window attention with the Earth-Specific bias,
         see https://github.com/microsoft/Swin-Transformer for the official implementation of 2D sliding window attention.
 
     Args:
@@ -749,40 +944,54 @@ class EarthAttention3D(nn.Module):
         window_size (Tuple[int, int, int]): window size (z, h ,w)
     """
 
-    def __init__(self, data_size: torch.Size, dim: int, num_heads: int, dropout_rate: float, window_size: Tuple[int, int, int]) -> None:
+    def __init__(
+        self,
+        data_size: torch.Size,
+        dim: int,
+        num_heads: int,
+        dropout_rate: float,
+        window_size: Tuple[int, int, int],
+    ) -> None:
         super().__init__()
-        
+
         # Store several attributes
         self.head_number = num_heads
         self.dim = dim
-        self.scale = (dim//num_heads)**-0.5
+        self.scale = (dim // num_heads) ** -0.5
         self.window_size = window_size
 
         # Construct position index to reuse self.earth_specific_bias
         self.register_buffer(
-            'position_index', define_3d_earth_position_index(window_size))
-        
+            "position_index", define_3d_earth_position_index(window_size)
+        )
+
         # Init earth specific bias
         # only pressure level and latitude have absolute bias, longitude is cyclic
         # data_size is plevel, latitude, longitude
-        self.num_windows = (data_size[0]//self.window_size[0])*(data_size[1]//self.window_size[1])
+        self.num_windows = (data_size[0] // self.window_size[0]) * (
+            data_size[1] // self.window_size[1]
+        )
 
         # For each window, we will construct a set of parameters according to the paper
         # Inside a window, plevel and latitude positions are absolute while longitude are relative
-        self.earth_specific_bias = nn.Parameter(torch.zeros((2 * self.window_size[2] - 1) * self.window_size[1]**2 * self.window_size[0]**2,
-                                                            self.num_windows, self.head_number
-                                                            )
-                                                )
+        self.earth_specific_bias = nn.Parameter(
+            torch.zeros(
+                (2 * self.window_size[2] - 1)
+                * self.window_size[1] ** 2
+                * self.window_size[0] ** 2,
+                self.num_windows,
+                self.head_number,
+            )
+        )
 
         # Initialize several operations
-        self.linear1 = Linear(dim, dim*3, bias=True)
+        self.linear1 = Linear(dim, dim * 3, bias=True)
         self.linear2 = Linear(dim, dim)
         self.softmax = Softmax(dim=-1)
         self.dropout = Dropout(p=dropout_rate)
 
         # Initialize the tensors using Truncated normal distribution
-        torch.nn.init.trunc_normal_(
-            self.earth_specific_bias, mean=0.0, std=0.02)
+        torch.nn.init.trunc_normal_(self.earth_specific_bias, mean=0.0, std=0.02)
 
     def forward(self, x: Tensor, mask: Tensor, batch_size: int) -> Tensor:
         # Record the original shape of the input (B*num_windows, window_size, dim)
@@ -792,50 +1001,94 @@ class EarthAttention3D(nn.Module):
         x = self.linear1(x)
 
         # reshape the data to calculate multi-head attention
-        qkv = x.reshape(shape=(
-            x.shape[0], x.shape[1], 3, self.head_number, self.dim // self.head_number))
-        query, key, value = qkv.permute((2, 0, 3, 1, 4))  # 3, B*num_windows, head_number, window_size, dim_head
+        qkv = x.reshape(
+            shape=(
+                x.shape[0],
+                x.shape[1],
+                3,
+                self.head_number,
+                self.dim // self.head_number,
+            )
+        )
+        query, key, value = qkv.permute(
+            (2, 0, 3, 1, 4)
+        )  # 3, B*num_windows, head_number, window_size, dim_head
 
         # Scale the attention
         query = query * self.scale
 
         # Calculated the attention, a learnable bias is added to fix the nonuniformity of the grid.
-        self.attention = query @ key.mT  # @ denotes matrix multiplication ; B*num_windows_lon*num_windows, head_number, window_size, window_size
+        self.attention = (
+            query @ key.mT
+        )  # @ denotes matrix multiplication ; B*num_windows_lon*num_windows, head_number, window_size, window_size
 
         # self.earth_specific_bias is a set of neural network parameters to optimize.
         assert isinstance(self.position_index, Tensor)
         earth_specific_bias = self.earth_specific_bias[self.position_index]
 
         # Reshape the learnable bias to the same shape as the attention matrix
-        earth_specific_bias = earth_specific_bias.reshape(shape=(self.window_size[0] * self.window_size[1] * self.window_size[2],
-                                                             self.window_size[0] * self.window_size[1] * self.window_size[2],
-                                                             self.num_windows, self.head_number))
+        earth_specific_bias = earth_specific_bias.reshape(
+            shape=(
+                self.window_size[0] * self.window_size[1] * self.window_size[2],
+                self.window_size[0] * self.window_size[1] * self.window_size[2],
+                self.num_windows,
+                self.head_number,
+            )
+        )
         earth_specific_bias = earth_specific_bias.permute((2, 3, 0, 1))
-        earth_specific_bias = earth_specific_bias.unsqueeze(0)  # 1, num_windows, head_number, window_size, window_size
+        earth_specific_bias = earth_specific_bias.unsqueeze(
+            0
+        )  # 1, num_windows, head_number, window_size, window_size
 
         # Add the Earth-Specific bias to the attention matrix
         attention_shape = self.attention.shape
         # Reshape and permute the lon dim to match the shape of earth_specific_bias
-        attention = self.attention.reshape(batch_size, self.num_windows, -1, self.head_number, attention_shape[-2], attention_shape[-1])
+        attention = self.attention.reshape(
+            batch_size,
+            self.num_windows,
+            -1,
+            self.head_number,
+            attention_shape[-2],
+            attention_shape[-1],
+        )
         attention = attention.permute(0, 2, 1, 3, 4, 5)
-        attention = attention.reshape(-1, self.num_windows, self.head_number, attention_shape[-2], attention_shape[-1])
+        attention = attention.reshape(
+            -1,
+            self.num_windows,
+            self.head_number,
+            attention_shape[-2],
+            attention_shape[-1],
+        )
         # add bias
         attention = attention + earth_specific_bias
         # Reshape the attention matrix back
-        attention = attention.reshape(batch_size, -1, self.num_windows, self.head_number, attention_shape[-2], attention_shape[-1])
+        attention = attention.reshape(
+            batch_size,
+            -1,
+            self.num_windows,
+            self.head_number,
+            attention_shape[-2],
+            attention_shape[-1],
+        )
         attention = attention.permute(0, 2, 1, 3, 4, 5)
         self.attention2 = attention.reshape(attention_shape)
 
         # Mask the attention between non-adjacent pixels, e.g., simply add -100 to the masked element.
         if mask is not None:
-            attention = self.attention2.view(batch_size, -1, self.head_number, original_shape[1], original_shape[1])
+            attention = self.attention2.view(
+                batch_size, -1, self.head_number, original_shape[1], original_shape[1]
+            )
             attention = attention + mask.unsqueeze(1).unsqueeze(0)
-            self.attention2 = attention.view(-1, self.head_number, original_shape[1], original_shape[1])
+            self.attention2 = attention.view(
+                -1, self.head_number, original_shape[1], original_shape[1]
+            )
         attention = self.softmax(self.attention2)
         attention = self.dropout(attention)
 
         # Calculated the tensor after spatial mixing.
-        x = attention @ value  # @ denote matrix multiplication ; B*num_windows, head_number, window_size, dim_head
+        x = (
+            attention @ value
+        )  # @ denote matrix multiplication ; B*num_windows, head_number, window_size, dim_head
 
         # Reshape tensor to the original shape
         x = x.permute((0, 2, 1, 3))  # B*num_windows, window_size, head_number, dim_head
@@ -857,8 +1110,8 @@ class MLP(nn.Module):
 
     def __init__(self, dim: int, dropout_rate: float) -> None:
         super().__init__()
-        self.linear1 = Linear(dim, dim*4)
-        self.linear2 = Linear(dim*4, dim)
+        self.linear1 = Linear(dim, dim * 4)
+        self.linear2 = Linear(dim * 4, dim)
         self.activation = GELU()
         self.drop = Dropout(p=dropout_rate)
 
@@ -869,4 +1122,3 @@ class MLP(nn.Module):
         x = self.linear2(x)
         x = self.drop(x)
         return x
-

--- a/mfai/torch/models/resnet.py
+++ b/mfai/torch/models/resnet.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, Union
 
 import torch
+from torch import Tensor
 import torch.nn as nn
 import torch.utils.model_zoo as model_zoo
 from dataclasses_json import dataclass_json
@@ -19,7 +20,10 @@ class ResNetEncoder(ResNet):
     - output channels specification of feature tensors (produced by encoder)
     - patching first convolution for arbitrary input channels
     """
-    def __init__(self, out_channels: tuple[int, ...], depth: int = 5, **kwargs: dict[str, Any]):
+
+    def __init__(
+        self, out_channels: tuple[int, ...], depth: int = 5, **kwargs: dict[str, Any]
+    ):
         super().__init__(**kwargs)
         self._depth = depth
         self._out_channels = out_channels
@@ -37,7 +41,7 @@ class ResNetEncoder(ResNet):
             self.layer4,
         ]
 
-    def forward(self, x: torch.Tensor) -> list[torch.Tensor]:
+    def forward(self, x: Tensor) -> list[Tensor]:
         features = []
         for i in range(self._depth + 1):
             x = self.stages[i](x)
@@ -45,11 +49,13 @@ class ResNetEncoder(ResNet):
 
         return features
 
-    def load_state_dict(self, state_dict: dict[str, Any], **kwargs: dict[str, Any]) -> None:
+    def load_state_dict(
+        self, state_dict: dict[str, Any], **kwargs: dict[str, Any]
+    ) -> None:
         state_dict.pop("fc.bias", None)
         state_dict.pop("fc.weight", None)
         super().load_state_dict(state_dict, **kwargs)
-    
+
     @property
     def out_channels(self) -> tuple[int, ...]:
         """Return channels dimensions for each tensor of forward output of encoder"""
@@ -95,7 +101,7 @@ class ResNetEncoder(ResNet):
             )
 
 
-ENCODERS_MAP: dict[Literal['resnet18', 'resnet34', 'resnet50'], dict[str, Any]] = {
+ENCODERS_MAP: dict[Literal["resnet18", "resnet34", "resnet50"], dict[str, Any]] = {
     "resnet18": {
         "encoder": ResNetEncoder,
         "pretrained_url": "https://dl.fbaipublicfiles.com/semiweaksupervision/model_files/semi_supervised_resnet18-d92f0530.pth",  # noqa
@@ -127,7 +133,7 @@ ENCODERS_MAP: dict[Literal['resnet18', 'resnet34', 'resnet50'], dict[str, Any]] 
 
 
 def get_resnet_encoder(
-    name: Literal['resnet18', 'resnet34', 'resnet50'],
+    name: Literal["resnet18", "resnet34", "resnet50"],
     in_channels: int = 3,
     depth: int = 5,
     weights: bool = True,
@@ -206,7 +212,7 @@ class ResNet50(torch.nn.Module):
         self.fc = torch.nn.Linear(512 * 4, num_classes)
         self.num_classes = num_classes
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         y_hat = self.encoder(x)[-1]
         y_hat = self.avgpool(y_hat)
         y_hat = y_hat.reshape(y_hat.shape[0], -1)

--- a/mfai/torch/models/segformer.py
+++ b/mfai/torch/models/segformer.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Literal, Sequence
 import torch
 from dataclasses_json import dataclass_json
 from einops import rearrange
-from torch import einsum, nn
+from torch import Tensor, einsum, nn
 
 from .base import BaseModel, ModelType
 
@@ -62,7 +62,7 @@ class DsConv2d(nn.Module):
             nn.Conv2d(nb_in_channels, nb_out_channels, kernel_size=1, bias=bias),
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         return self.net(x)
 
 
@@ -73,7 +73,7 @@ class LayerNorm(nn.Module):
         self.g = nn.Parameter(torch.ones(1, dim, 1, 1))
         self.b = nn.Parameter(torch.zeros(1, dim, 1, 1))
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         std = torch.var(x, dim=1, unbiased=False, keepdim=True).sqrt()
         mean = torch.mean(x, dim=1, keepdim=True)
         return (x - mean) / (std + self.eps) * self.g + self.b
@@ -85,7 +85,7 @@ class PreNorm(nn.Module):
         self.fn = fn
         self.norm = LayerNorm(dim)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         return self.fn(self.norm(x))
 
 
@@ -111,13 +111,13 @@ class EfficientSelfAttention(nn.Module):
         )
         self.to_out = nn.Conv2d(dim, dim, 1, bias=False)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         h, w = x.shape[-2:]
         heads = self.heads
 
-        q: torch.Tensor = self.to_q(x)
-        k: torch.Tensor
-        v: torch.Tensor
+        q: Tensor = self.to_q(x)
+        k: Tensor
+        v: Tensor
         k, v = self.to_kv(x).chunk(2, dim=1)
         q, k, v = map(
             lambda t: rearrange(t, "b (h c) x y -> (b h) (x y) c", h=heads), (q, k, v)
@@ -142,7 +142,7 @@ class MixFeedForward(nn.Module):
             nn.Conv2d(hidden_dim, dim, 1),
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         return self.net(x)
 
 
@@ -212,8 +212,8 @@ class MiT(nn.Module):
             )
 
     def forward(
-        self, x: torch.Tensor, return_layer_outputs: bool = False
-    ) -> torch.Tensor | list[torch.Tensor]:
+        self, x: Tensor, return_layer_outputs: bool = False
+    ) -> Tensor | list[Tensor]:
         h, w = x.shape[-2:]
 
         layer_outputs = []
@@ -346,12 +346,12 @@ class Segformer(BaseModel):
     def settings(self) -> SegformerSettings:
         return self._settings
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         x = self.downsampler(x)
-        layer_outputs: list[torch.Tensor] = self.mit(x, return_layer_outputs=True)
+        layer_outputs: list[Tensor] = self.mit(x, return_layer_outputs=True)
 
-        fused: list[torch.Tensor] = [
+        fused: list[Tensor] = [
             to_fused(output) for output, to_fused in zip(layer_outputs, self.to_fused)
         ]
-        out: torch.Tensor = torch.cat(fused, dim=1)
+        out: Tensor = torch.cat(fused, dim=1)
         return self.upsampler(out)

--- a/mfai/torch/models/swinunetr.py
+++ b/mfai/torch/models/swinunetr.py
@@ -5,7 +5,7 @@ import torch
 from dataclasses_json import dataclass_json
 from monai.networks.blocks.dynunet_block import UnetResBlock
 from monai.networks.nets.swin_unetr import SwinUNETR as MonaiSwinUNETR
-from torch import nn
+from torch import Tensor, nn
 
 from .base import ModelABC, ModelType
 
@@ -22,7 +22,7 @@ class SwinUNETRSettings:
     dropout_path_rate: float = 0.0
     normalize: bool = True
     use_checkpoint: bool = False
-    downsample: Literal['merging', 'merginv2'] | nn.Module = "merging"
+    downsample: Literal["merging", "merginv2"] | nn.Module = "merging"
     use_v2: bool = False
 
 
@@ -50,7 +50,7 @@ class UpsampleBlock(nn.Module):
             norm_name=norm_name,
         )
 
-    def forward(self, inp: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
+    def forward(self, inp: Tensor, skip: Tensor) -> Tensor:
         out = self.upsampler(inp)
         # concat along the channels/features dimension
         out = torch.cat((out, skip), dim=1)
@@ -63,9 +63,10 @@ class SwinUNETR(ModelABC, MonaiSwinUNETR):
     Wrapper around the SwinUNETR from MONAI.
     Instanciated in 2D for now, with a custom decoder.
     """
+
     settings_kls = SwinUNETRSettings
     onnx_supported: bool = False
-    supported_num_spatial_dims: tuple[int,...] = (2,)
+    supported_num_spatial_dims: tuple[int, ...] = (2,)
     features_last: bool = False
     model_type: ModelType = ModelType.VISION_TRANSFORMER
     num_spatial_dims: int = 2
@@ -77,8 +78,8 @@ class SwinUNETR(ModelABC, MonaiSwinUNETR):
         out_channels: int,
         input_shape: tuple[int, ...] = (1,),
         settings: SwinUNETRSettings = SwinUNETRSettings(),
-        *args:Any,
-        **kwargs:Any,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             in_channels=in_channels,

--- a/mfai/torch/models/unet.py
+++ b/mfai/torch/models/unet.py
@@ -13,7 +13,7 @@ from typing import Literal, Tuple
 
 import torch
 from dataclasses_json import dataclass_json
-from torch import nn
+from torch import Tensor, nn
 
 from .base import AutoPaddingModel, BaseModel, ModelType
 from .resnet import get_resnet_encoder
@@ -53,7 +53,7 @@ class DoubleConv(nn.Module):
             )
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         return self.double_conv(x)
 
 
@@ -128,7 +128,7 @@ class UNet(BaseModel, AutoPaddingModel):
     def settings(self) -> UnetSettings:
         return self._settings
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         """
         Description of the architecture from the original paper (https://arxiv.org/pdf/1505.04597.pdf):
         The network architecture is illustrated in Figure 1. It consists of a contracting
@@ -297,7 +297,7 @@ class CustomUnet(BaseModel, AutoPaddingModel):
     def settings(self) -> CustomUnetSettings:
         return self._settings
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         x, old_shape = self._maybe_padding(data_tensor=x)
         # Encoder part
         encoder_outputs = self.encoder(x)

--- a/mfai/torch/models/unetrpp.py
+++ b/mfai/torch/models/unetrpp.py
@@ -65,7 +65,7 @@ def _trunc_normal_(tensor, mean, std, a, b):
 
 
 def trunc_normal_(tensor, mean=0.0, std=1.0, a=-2.0, b=2.0):
-    # type: (torch.Tensor, float, float, float, float) -> torch.Tensor
+    # type: (Tensor, float, float, float, float) -> Tensor
     r"""Fills the input Tensor with values drawn from a truncated
     normal distribution. The values are effectively drawn from the
     normal distribution :math:`\mathcal{N}(\text{mean}, \text{std}^2)`
@@ -78,7 +78,7 @@ def trunc_normal_(tensor, mean=0.0, std=1.0, a=-2.0, b=2.0):
     should be adjusted to match the range of mean, std args.
 
     Args:
-        tensor: an n-dimensional `torch.Tensor`
+        tensor: an n-dimensional `Tensor`
         mean: the mean of the normal distribution
         std: the standard deviation of the normal distribution
         a: the minimum cutoff value

--- a/mfai/torch/models/utils.py
+++ b/mfai/torch/models/utils.py
@@ -3,6 +3,7 @@ from typing import Tuple
 
 import einops
 import torch
+from torch import Tensor
 import torch.nn as nn
 
 
@@ -29,7 +30,7 @@ def patch_first_conv(
 
     if not pretrained:
         first_conv.weight = nn.parameter.Parameter(
-            torch.Tensor(
+            Tensor(
                 first_conv.out_channels,
                 new_in_channels // first_conv.groups,
                 *first_conv.kernel_size,
@@ -42,7 +43,7 @@ def patch_first_conv(
         first_conv.weight = nn.parameter.Parameter(new_weight)
 
     else:
-        new_weight = torch.Tensor(
+        new_weight = Tensor(
             first_conv.out_channels,
             new_in_channels // first_conv.groups,
             *first_conv.kernel_size,
@@ -92,32 +93,32 @@ class AbsolutePosEmdebding(nn.Module):
                 requires_grad=True,
             )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         return x + self.pos_embedding
 
 
-def init_(tensor: torch.Tensor, dim_idx: int = -1) -> torch.Tensor:
+def init_(tensor: Tensor, dim_idx: int = -1) -> Tensor:
     dim: int = tensor.shape[dim_idx]
     std: float = 1 / math.sqrt(dim)
     tensor.uniform_(-std, std)
     return tensor
 
 
-def features_last_to_second(x: torch.Tensor) -> torch.Tensor:
+def features_last_to_second(x: Tensor) -> Tensor:
     """
     Moves features from the last dimension to the second dimension.
     """
     return einops.rearrange(x, "b x y n -> b n x y").contiguous()
 
 
-def features_second_to_last(y: torch.Tensor) -> torch.Tensor:
+def features_second_to_last(y: Tensor) -> Tensor:
     """
     Moves features from the second dimension to the last dimension.
     """
     return einops.rearrange(y, "b n x y -> b x y n").contiguous()
 
 
-def expand_to_batch(x: torch.Tensor, batch_size: int) -> torch.Tensor:
+def expand_to_batch(x: Tensor, batch_size: int) -> Tensor:
     """
     Expand tensor with initial batch dimension
     """

--- a/mfai/torch/namedtensor.py
+++ b/mfai/torch/namedtensor.py
@@ -10,6 +10,7 @@ from typing import Any, List, Sequence, Union
 
 import einops
 import torch
+from torch import Tensor
 from tabulate import tabulate
 
 
@@ -22,7 +23,7 @@ class TensorWrapper:
     "Trying to infer the `batch_size` from an ambiguous collection ..."
     """
 
-    tensor: torch.Tensor
+    tensor: Tensor
 
 
 class NamedTensor(TensorWrapper):
@@ -47,7 +48,7 @@ class NamedTensor(TensorWrapper):
 
     def __init__(
         self,
-        tensor: torch.Tensor,
+        tensor: Tensor,
         names: List[str],
         feature_names: List[str],
         feature_dim_name: str = "features",
@@ -222,7 +223,7 @@ class NamedTensor(TensorWrapper):
             feature_names=self.feature_names.copy(),
         )
 
-    def __getitem__(self, feature_name: str) -> torch.Tensor:
+    def __getitem__(self, feature_name: str) -> Tensor:
         """
         Get one feature from the features dimension of the tensor by name.
         The returned tensor has the same number of dimensions as the original tensor.
@@ -310,14 +311,14 @@ class NamedTensor(TensorWrapper):
             feature_dim_name=self.feature_dim_name,
         )
 
-    def select_tensor_dim(self, dim_name: str, index: int) -> torch.Tensor:
+    def select_tensor_dim(self, dim_name: str, index: int) -> Tensor:
         """
-        Same as select_dim but returns a torch.Tensor.
+        Same as select_dim but returns a Tensor.
         Allows the selection of the feature dimension.
         """
         return self.tensor.select(self.names.index(dim_name), index)
 
-    def index_select_dim(self, dim_name: str, indices: torch.Tensor) -> "NamedTensor":
+    def index_select_dim(self, dim_name: str, indices: Tensor) -> "NamedTensor":
         """
         Return the tensor indexed along the dimension dim_name
         with the indices tensor.
@@ -329,7 +330,7 @@ class NamedTensor(TensorWrapper):
         return NamedTensor(
             self.tensor.index_select(
                 self.names.index(dim_name),
-                torch.Tensor(indices).type(torch.int64).to(self.device),
+                Tensor(indices).type(torch.int64).to(self.device),
             ),
             self.names,
             (
@@ -340,15 +341,13 @@ class NamedTensor(TensorWrapper):
             feature_dim_name=self.feature_dim_name,
         )
 
-    def index_select_tensor_dim(
-        self, dim_name: str, indices: torch.Tensor
-    ) -> torch.Tensor:
+    def index_select_tensor_dim(self, dim_name: str, indices: Tensor) -> Tensor:
         """
-        Same as index_select_dim but returns a torch.tensor, but returns a torch.Tensor.
+        Same as index_select_dim but returns a Tensor, but returns a Tensor.
         """
         return self.tensor.index_select(
             self.names.index(dim_name),
-            torch.Tensor(indices).type(torch.int64).to(self.device),
+            Tensor(indices).type(torch.int64).to(self.device),
         )
 
     def dim_size(self, dim_name: str) -> int:
@@ -400,7 +399,7 @@ class NamedTensor(TensorWrapper):
         for i in range(self.dim_size(dim_name)):
             yield self.select_dim(dim_name, i)
 
-    def iter_tensor_dim(self, dim_name: str) -> Iterable[torch.Tensor]:
+    def iter_tensor_dim(self, dim_name: str) -> Iterable[Tensor]:
         """
         Iterate over the tensor along a given dimension.
         """
@@ -424,7 +423,7 @@ class NamedTensor(TensorWrapper):
         self.names = new_dims
 
     @staticmethod
-    def new_like(tensor: torch.Tensor, other: "NamedTensor") -> "NamedTensor":
+    def new_like(tensor: Tensor, other: "NamedTensor") -> "NamedTensor":
         """
         Create a new NamedTensor with the same names and feature names as another NamedTensor
         and a tensor of the same shape as the input tensor.
@@ -432,9 +431,7 @@ class NamedTensor(TensorWrapper):
         return NamedTensor(tensor, other.names.copy(), other.feature_names.copy())
 
     @staticmethod
-    def expand_to_batch_like(
-        tensor: torch.Tensor, other: "NamedTensor"
-    ) -> "NamedTensor":
+    def expand_to_batch_like(tensor: Tensor, other: "NamedTensor") -> "NamedTensor":
         """
         Create a new NamedTensor with the same names and feature names as another NamedTensor
         with an extra first dimension called 'batch' using the supplied tensor.

--- a/mfai/torch/padding.py
+++ b/mfai/torch/padding.py
@@ -1,24 +1,25 @@
 import torch.nn.functional as F
 import torch
+from torch import Tensor
 from typing import Tuple, Optional
 
 
 def pad_batch(
-    batch: torch.Tensor,
+    batch: Tensor,
     new_shape: torch.Size,
     mode: str = "constant",
     pad_value: Optional[float] = 0,
-) -> torch.Tensor:
+) -> Tensor:
     """Given batch of 2D or 3D data and a shape new_shape,
         pads the tensor with the given pad_value.
 
     Args:
-        batch (torch.Tensor): the batch of values of shape (B, C, D, H, W) or (B, C, H, W).
+        batch (Tensor): the batch of values of shape (B, C, D, H, W) or (B, C, H, W).
         new_shape (torch.Size): Target shape (D, H, W) for 3D tensors or (H, W) for 2D tensors to be given.
         pad_value (float, optional): the padding value to be used. Defaults to 0.
 
     Returns:
-        torch.Tensor: The padded tensor.
+        Tensor: The padded tensor.
     """
 
     fits = batch.shape[-len(new_shape) :] == new_shape
@@ -84,13 +85,11 @@ def _get_3D_padding(
     return left, right, top, bottom, front, back
 
 
-def undo_padding(
-    batch: torch.Tensor, old_shape: torch.Size, inplace: bool = False
-) -> torch.Tensor:
+def undo_padding(batch: Tensor, old_shape: torch.Size, inplace: bool = False) -> Tensor:
     """Removes the padding added by pad_batch
 
     Args:
-        batch (torch.Tensor): The padded batch of data
+        batch (Tensor): The padded batch of data
         old_shape (torch.Size): The original shape of the data
         inplace (bool): Whether the returned tensor is just a sliced view of the
                         given tensor or a new copy.

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -28,7 +28,7 @@ def test_llms(model_target_tokenizer):
     model = model()
     start_context = "Hello, I am"
     encoded = tokenizer.encode(start_context)
-    encoded_tensor = Tensor(encoded).unsqueeze(0)
+    encoded_tensor = torch.tensor(encoded).unsqueeze(0)
 
     out = generate_text_simple(
         model=model,

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -1,6 +1,7 @@
 from functools import partial
 import pytest
 import torch
+from torch import Tensor
 from mfai.torch.models.llms import Llama2Settings, Llama2, GPT2, GPT2Settings
 from mfai.tokenizers import LlamaTokenizer, GPT2Tokenizer
 from test_multimodal_lm import generate_text_simple
@@ -27,7 +28,7 @@ def test_llms(model_target_tokenizer):
     model = model()
     start_context = "Hello, I am"
     encoded = tokenizer.encode(start_context)
-    encoded_tensor = torch.tensor(encoded).unsqueeze(0)
+    encoded_tensor = Tensor(encoded).unsqueeze(0)
 
     out = generate_text_simple(
         model=model,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,6 +5,7 @@ Tests for our pytorch metrics
 import numpy as np
 import pytest
 import torch
+from torch import Tensor
 from mfai.torch.metrics import CSINeighborood, PR_AUC, FAR, FNR
 
 
@@ -14,7 +15,7 @@ def test_csi_binary(num_neighbors: int, expected_value: float):
     Build tensors of size (2, 1, 5, 5), compute the CSI for binary task and check if the output is
     the result expected.
     """
-    y_true = torch.tensor(
+    y_true = Tensor(
         np.array(
             [
                 [
@@ -38,7 +39,7 @@ def test_csi_binary(num_neighbors: int, expected_value: float):
             ]
         )
     )
-    y_hat = torch.tensor(
+    y_hat = Tensor(
         np.array(
             [
                 [
@@ -71,12 +72,12 @@ def test_csi_binary(num_neighbors: int, expected_value: float):
 
 
 @pytest.mark.parametrize("num_neighbors,expected_value", [(0, 0.43), (1, 0.79)])
-def test_csi_multiclass(num_neighbors: int, expected_value: torch.Tensor):
+def test_csi_multiclass(num_neighbors: int, expected_value: Tensor):
     """
     Build tensors of size (1, 1, 5, 5), compute the CSI for multiclass taskand check if the output is
     the result expected.
     """
-    y_true = torch.tensor(
+    y_true = Tensor(
         np.array(
             [
                 [
@@ -91,7 +92,7 @@ def test_csi_multiclass(num_neighbors: int, expected_value: torch.Tensor):
             ]
         )
     )
-    y_hat = torch.tensor(
+    y_hat = Tensor(
         np.array(
             [
                 [
@@ -115,12 +116,12 @@ def test_csi_multiclass(num_neighbors: int, expected_value: torch.Tensor):
 
 
 @pytest.mark.parametrize("num_neighbors,expected_value", [(0, 0.36), (1, 0.81)])
-def test_csi_multilabel(num_neighbors: int, expected_value: torch.Tensor):
+def test_csi_multilabel(num_neighbors: int, expected_value: Tensor):
     """
     Build tensors of size (1, 3, 5, 5), compute the CSI for multilabel task and check if the output is
     the result expected.
     """
-    y_true = torch.tensor(
+    y_true = Tensor(
         np.array(
             [
                 [
@@ -149,7 +150,7 @@ def test_csi_multilabel(num_neighbors: int, expected_value: torch.Tensor):
             ]
         )
     )
-    y_hat = torch.tensor(
+    y_hat = Tensor(
         np.array(
             [
                 [
@@ -190,8 +191,8 @@ def test_pr_auc():
     """
     Test of the compute of the Precision-Recall Area Under the Curve.
     """
-    preds = torch.tensor([0.0, 1.0, 0.0, 1.0])
-    targets = torch.tensor([0, 0, 1, 1])
+    preds = Tensor([0.0, 1.0, 0.0, 1.0])
+    targets = Tensor([0, 0, 1, 1])
     far = PR_AUC()
     far.update(preds, targets)
     auc_value = far.compute()
@@ -203,8 +204,8 @@ def test_far():
     """
     Test of the compute of the False Alarm Rate.
     """
-    preds = torch.tensor([0.0, 1.0, 0.0, 1.0])
-    targets = torch.tensor([0, 0, 1, 1])
+    preds = Tensor([0.0, 1.0, 0.0, 1.0])
+    targets = Tensor([0, 0, 1, 1])
     far = FAR("binary")
     far.update(preds, targets)
     auc_value = far.compute()
@@ -216,8 +217,8 @@ def test_fnr():
     """
     Test of the compute of the False Alarm Rate.
     """
-    preds = torch.tensor([0.0, 1.0, 0.0, 1.0])
-    targets = torch.tensor([0, 0, 1, 1])
+    preds = Tensor([0.0, 1.0, 0.0, 1.0])
+    targets = Tensor([0, 0, 1, 1])
     fnr = FNR()
     fnr.update(preds, targets)
     auc_value = fnr.compute()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -15,7 +15,7 @@ def test_csi_binary(num_neighbors: int, expected_value: float):
     Build tensors of size (2, 1, 5, 5), compute the CSI for binary task and check if the output is
     the result expected.
     """
-    y_true = Tensor(
+    y_true = torch.tensor(
         np.array(
             [
                 [
@@ -39,7 +39,7 @@ def test_csi_binary(num_neighbors: int, expected_value: float):
             ]
         )
     )
-    y_hat = Tensor(
+    y_hat = torch.tensor(
         np.array(
             [
                 [
@@ -77,7 +77,7 @@ def test_csi_multiclass(num_neighbors: int, expected_value: Tensor):
     Build tensors of size (1, 1, 5, 5), compute the CSI for multiclass taskand check if the output is
     the result expected.
     """
-    y_true = Tensor(
+    y_true = torch.tensor(
         np.array(
             [
                 [
@@ -92,7 +92,7 @@ def test_csi_multiclass(num_neighbors: int, expected_value: Tensor):
             ]
         )
     )
-    y_hat = Tensor(
+    y_hat = torch.tensor(
         np.array(
             [
                 [
@@ -121,7 +121,7 @@ def test_csi_multilabel(num_neighbors: int, expected_value: Tensor):
     Build tensors of size (1, 3, 5, 5), compute the CSI for multilabel task and check if the output is
     the result expected.
     """
-    y_true = Tensor(
+    y_true = torch.tensor(
         np.array(
             [
                 [
@@ -150,7 +150,7 @@ def test_csi_multilabel(num_neighbors: int, expected_value: Tensor):
             ]
         )
     )
-    y_hat = Tensor(
+    y_hat = torch.tensor(
         np.array(
             [
                 [
@@ -191,8 +191,8 @@ def test_pr_auc():
     """
     Test of the compute of the Precision-Recall Area Under the Curve.
     """
-    preds = Tensor([0.0, 1.0, 0.0, 1.0])
-    targets = Tensor([0, 0, 1, 1])
+    preds = torch.tensor([0.0, 1.0, 0.0, 1.0])
+    targets = torch.tensor([0, 0, 1, 1])
     far = PR_AUC()
     far.update(preds, targets)
     auc_value = far.compute()
@@ -204,8 +204,8 @@ def test_far():
     """
     Test of the compute of the False Alarm Rate.
     """
-    preds = Tensor([0.0, 1.0, 0.0, 1.0])
-    targets = Tensor([0, 0, 1, 1])
+    preds = torch.tensor([0.0, 1.0, 0.0, 1.0])
+    targets = torch.tensor([0, 0, 1, 1])
     far = FAR("binary")
     far.update(preds, targets)
     auc_value = far.compute()
@@ -217,8 +217,8 @@ def test_fnr():
     """
     Test of the compute of the False Alarm Rate.
     """
-    preds = Tensor([0.0, 1.0, 0.0, 1.0])
-    targets = Tensor([0, 0, 1, 1])
+    preds = torch.tensor([0.0, 1.0, 0.0, 1.0])
+    targets = torch.tensor([0, 0, 1, 1])
     fnr = FNR()
     fnr.update(preds, targets)
     auc_value = fnr.compute()

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -98,7 +98,7 @@ def test_multimodal_llm(
             feature_names=("u",),
         )
         encoded = tokenizer.encode("Sustine et abstine")
-        encoded_tensor = Tensor(encoded).unsqueeze(0)
+        encoded_tensor = torch.tensor(encoded).unsqueeze(0)
 
         out = generate_text_simple(
             model=model,
@@ -135,7 +135,7 @@ def test_multimodal_clip():
         feature_names=("u",),
     )
     encoded = tokenizer.encode("Sustine et abstine")
-    encoded_tensor = Tensor(encoded).unsqueeze(0)
+    encoded_tensor = torch.tensor(encoded).unsqueeze(0)
 
     out = generate_text_simple(
         model=model,

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -7,6 +7,8 @@ from torch import Tensor, nn
 from mfai.tokenizers import GPT2Tokenizer, LlamaTokenizer
 from mfai.torch.models.llms.multimodal import MultiModalLM, MultiModalLMSettings
 from mfai.torch.namedtensor import NamedTensor
+
+
 def generate_text_simple(
     model: nn.Module,
     idx: Tensor,
@@ -96,7 +98,7 @@ def test_multimodal_llm(
             feature_names=("u",),
         )
         encoded = tokenizer.encode("Sustine et abstine")
-        encoded_tensor = torch.tensor(encoded).unsqueeze(0)
+        encoded_tensor = Tensor(encoded).unsqueeze(0)
 
         out = generate_text_simple(
             model=model,
@@ -133,7 +135,7 @@ def test_multimodal_clip():
         feature_names=("u",),
     )
     encoded = tokenizer.encode("Sustine et abstine")
-    encoded_tensor = torch.tensor(encoded).unsqueeze(0)
+    encoded_tensor = Tensor(encoded).unsqueeze(0)
 
     out = generate_text_simple(
         model=model,

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from torch import Tensor
 
 from mfai.torch.padding import pad_batch, undo_padding
 
@@ -7,12 +8,10 @@ from mfai.torch.padding import pad_batch, undo_padding
 @pytest.mark.parametrize("dims", [2, 3])
 def test_pad(dims):
     # get all the True/False combinations
-    combinations = torch.cartesian_prod(*[torch.tensor([0, 1]) for _ in range(dims)])
+    combinations = torch.cartesian_prod(*[Tensor([0, 1]) for _ in range(dims)])
     even = 8
     odd = 9
-    mapped_combinations = torch.where(
-        combinations == 1, torch.tensor(even), torch.tensor(odd)
-    )
+    mapped_combinations = torch.where(combinations == 1, Tensor(even), Tensor(odd))
 
     for comb in mapped_combinations:
         # initial data with 8 batch elements, 3 channels and a combination of even and odd data dimensions

--- a/tests/test_padding.py
+++ b/tests/test_padding.py
@@ -8,10 +8,12 @@ from mfai.torch.padding import pad_batch, undo_padding
 @pytest.mark.parametrize("dims", [2, 3])
 def test_pad(dims):
     # get all the True/False combinations
-    combinations = torch.cartesian_prod(*[Tensor([0, 1]) for _ in range(dims)])
+    combinations = torch.cartesian_prod(*[torch.tensor([0, 1]) for _ in range(dims)])
     even = 8
     odd = 9
-    mapped_combinations = torch.where(combinations == 1, Tensor(even), Tensor(odd))
+    mapped_combinations = torch.where(
+        combinations == 1, torch.tensor(even), torch.tensor(odd)
+    )
 
     for comb in mapped_combinations:
         # initial data with 8 batch elements, 3 channels and a combination of even and odd data dimensions


### PR DESCRIPTION
As stated, change the use of `torch.Tensor` to `Tensor`.
There is no ambiguity in doing so, this librairy do not mix multiple tensor classes.

Helps with readability.