### PR TITLE
<tokenizer> fix EOT that change of ID after adding special token

### DIFF
--- a/mfai/tokenizers/__init__.py
+++ b/mfai/tokenizers/__init__.py
@@ -58,20 +58,22 @@ class GPT2Tokenizer(Tokenizer):
         https://github.com/openai/tiktoken/tree/main?tab=readme-ov-file#extending-tiktoken
         """
         for tok in new_special_tokens:
-            if tok not in self.special_tokens and tok not in self.base_tokenizer._special_tokens:
+            if (
+                tok not in self.special_tokens
+                and tok not in self.base_tokenizer._special_tokens
+            ):
                 self.special_tokens.append(tok)
 
         special_tokens = {
-                tok: self.base_tokenizer.n_vocab + i
-                for i, tok in enumerate(self.special_tokens)
-            }
-        
+            tok: self.base_tokenizer.n_vocab + i
+            for i, tok in enumerate(self.special_tokens)
+        }
 
         self.tokenizer = tiktoken.Encoding(
             name=f"custom_{self.name()}",
             pat_str=self.base_tokenizer._pat_str,
             mergeable_ranks=self.base_tokenizer._mergeable_ranks,
-            special_tokens= {**self.base_tokenizer._special_tokens} | special_tokens,
+            special_tokens={**self.base_tokenizer._special_tokens} | special_tokens,
         )
 
     def name(self) -> str:

--- a/mfai/tokenizers/__init__.py
+++ b/mfai/tokenizers/__init__.py
@@ -51,9 +51,6 @@ class GPT2Tokenizer(Tokenizer):
         self.special_tokens: list[str] = []
         self.tokenizer = self.base_tokenizer
 
-        # Always add the <|endoftext|> token
-        self.add_special_tokens(["<|endoftext|>"])
-
     def add_special_tokens(self, new_special_tokens: list[str]) -> None:
         """
         Method to add some special tokens to the tokenizer.
@@ -62,24 +59,27 @@ class GPT2Tokenizer(Tokenizer):
         https://github.com/openai/tiktoken/tree/main?tab=readme-ov-file#extending-tiktoken
         """
         for tok in new_special_tokens:
-            if tok not in self.special_tokens:
+            if tok not in self.special_tokens and tok not in self.base_tokenizer._special_tokens:
                 self.special_tokens.append(tok)
+
+        special_tokens = {
+                tok: self.base_tokenizer.n_vocab + i
+                for i, tok in enumerate(self.special_tokens)
+            }
+        
 
         self.tokenizer = tiktoken.Encoding(
             name=f"custom_{self.name()}",
             pat_str=self.base_tokenizer._pat_str,
             mergeable_ranks=self.base_tokenizer._mergeable_ranks,
-            special_tokens={
-                tok: self.base_tokenizer.n_vocab + i
-                for i, tok in enumerate(self.special_tokens)
-            },
+            special_tokens= {**self.base_tokenizer._special_tokens} | special_tokens,
         )
 
     def name(self) -> str:
         return "gpt2"
 
     def encode(self, text: str, *args: Any, **kwargs: Any) -> List[int]:
-        return self.tokenizer.encode(text, *args, **kwargs, allowed_special="all")
+        return self.tokenizer.encode(text, allowed_special="all", *args, **kwargs)
 
     def decode(self, tokens: list, *args: Any, **kwargs: Any) -> str:
         return self.tokenizer.decode(tokens, *args, **kwargs)
@@ -174,9 +174,13 @@ class MiniGPT2Tokenizer(Tokenizer, ABC):
         for idx, token_id in enumerate(self.tokens()):
             self.token_to_id[token_id] = idx
             self.id_to_token[idx] = token_id
-
-        self.add_special_tokens(["<|endoftext|>"])
-
+        
+        # Add manualy the EOT token if needed
+        mini_eot_id = self.vocab_size
+        base_eot_id = self.gpt2_tokenizer.encode("<|endoftext|>")[0]
+        if base_eot_id not in self.token_to_id.keys():
+            self.token_to_id[base_eot_id] = mini_eot_id
+            self.id_to_token[mini_eot_id] = base_eot_id
 
     def add_special_tokens(self, special_tokens: list[str]) -> None:
         """

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -62,8 +62,8 @@ def generate_text_simple(
             "gpt2",
             GPT2Tokenizer(),
             (
-                "Sustine et abstinegru notionsickenburgrant Iz Everybodyعcontact ig",
-                "Sustine et abstine GingLocal acids swallowAsset Investigatorothermaladanwebopath",
+                "Sustine et abstinegreg LXamm Local addition Immun GlassrikeFal Resurrection",
+                "Sustine et abstineohoorphLE updates� Oaks Coconut VC Privacy backward",
             ),
         ),
         (

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -48,5 +48,7 @@ def test_add_special_tokens(tokenizer: Tokenizer):
 
     # Check that the EOT doesn't change his ID after adding some new tokens
     assert base_tokenizer.encode("<|endoftext|>") == tokenizer.encode("<|endoftext|>")
-    assert base_tokenizer.decode(base_tokenizer.encode("<|endoftext|>")) == tokenizer.decode(tokenizer.encode("<|endoftext|>"))
+    assert base_tokenizer.decode(
+        base_tokenizer.encode("<|endoftext|>")
+    ) == tokenizer.decode(tokenizer.encode("<|endoftext|>"))
     assert tokenizer.decode([base_tokenizer.vocab_size - 1]) == "<|endoftext|>"

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -44,3 +44,8 @@ def test_add_special_tokens(tokenizer: Tokenizer):
     assert text_encoded[0] == tokenizer.vocab_size - 1
     # Check that the encoding of <|endoftext|> is unchanged after adding some new token
     assert text_encoded[-1] == base_tokenizer.eot_token
+
+    # Check that the EOT doesn't change his ID after adding some new tokens
+    assert base_tokenizer.encode("<|endoftext|>") == tokenizer.encode("<|endoftext|>")
+    assert base_tokenizer.decode(base_tokenizer.encode("<|endoftext|>")) == tokenizer.decode(tokenizer.encode("<|endoftext|>"))
+    assert tokenizer.decode([base_tokenizer.vocab_size - 1]) == "<|endoftext|>"


### PR DESCRIPTION
This PR fix the old behavior that the token id of the EOT token changed when the use 'add_sepcial_tokens' method.

BEFORE:
```
>tokenizer = GPT2Tokenizer()
>tokenizer.encode("<|endoftext|>")
50256
>tokenizer.adds_special_tokens("<|my_token|>")
>tokenizer.encode("<|endoftext|>")
50257
```

NOW:
```
>tokenizer = GPT2Tokenizer()
>tokenizer.encode("<|endoftext|>")
50256
>tokenizer.adds_special_tokens("<|my_token|>")
>tokenizer.encode("<|endoftext|>")
50256
```