### PR TITLE
fix UnetrUpBlock kernel_size misuse

### DIFF
--- a/mfai/torch/models/unetrpp.py
+++ b/mfai/torch/models/unetrpp.py
@@ -509,14 +509,14 @@ class UnetrUpBlock(nn.Module):
         self.transp_conv: nn.Module
         if spatial_dims == 2:
             if linear_upsampling:
-                if isinstance(kernel_size, tuple):
+                if isinstance(upsample_kernel_size, tuple):
                     scale_factor: tuple[float, float] | float = (
-                        float(kernel_size[0]),
-                        float(kernel_size[1]),
+                        float(upsample_kernel_size[0]),
+                        float(upsample_kernel_size[1]),
                     )
-                    kernel_size = kernel_size[:2]
+                    upsample_kernel_size = upsample_kernel_size[:2]
                 else:
-                    scale_factor = float(kernel_size)
+                    scale_factor = float(upsample_kernel_size)
                 self.transp_conv = nn.Sequential(
                     nn.UpsamplingBilinear2d(scale_factor=scale_factor),
                     nn.Conv2d(

--- a/mfai/torch/models/unetrpp.py
+++ b/mfai/torch/models/unetrpp.py
@@ -520,7 +520,10 @@ class UnetrUpBlock(nn.Module):
                 self.transp_conv = nn.Sequential(
                     nn.UpsamplingBilinear2d(scale_factor=scale_factor),
                     nn.Conv2d(
-                        in_channels, out_channels, kernel_size=upsample_kernel_size, padding=1
+                        in_channels,
+                        out_channels,
+                        kernel_size=upsample_kernel_size,
+                        padding=1,
                     ),
                 )
             else:

--- a/mfai/torch/models/unetrpp.py
+++ b/mfai/torch/models/unetrpp.py
@@ -517,12 +517,14 @@ class UnetrUpBlock(nn.Module):
                     upsample_kernel_size = upsample_kernel_size[:2]
                 else:
                     scale_factor = float(upsample_kernel_size)
+                if isinstance(kernel_size, tuple):
+                    kernel_size = kernel_size[:2]
                 self.transp_conv = nn.Sequential(
                     nn.UpsamplingBilinear2d(scale_factor=scale_factor),
                     nn.Conv2d(
                         in_channels,
                         out_channels,
-                        kernel_size=upsample_kernel_size,
+                        kernel_size=kernel_size,
                         padding=1,
                     ),
                 )

--- a/mfai/torch/models/unetrpp.py
+++ b/mfai/torch/models/unetrpp.py
@@ -520,7 +520,7 @@ class UnetrUpBlock(nn.Module):
                 self.transp_conv = nn.Sequential(
                     nn.UpsamplingBilinear2d(scale_factor=scale_factor),
                     nn.Conv2d(
-                        in_channels, out_channels, kernel_size=kernel_size, padding=1
+                        in_channels, out_channels, kernel_size=upsample_kernel_size, padding=1
                     ),
                 )
             else:


### PR DESCRIPTION
🚑 hot fix
[PR#56](https://github.com/meteofrance/mfai/pull/56) changed Unetrpp's behavior.

In case of `sparial_dims == 2` and `linear_upsampling`, the `UnetrUpBlock` used to define it's transp_conv as a `nn.Sequential` with a `nn.UpsamplingBilinear2d` instantiated with it's init parameter `scale_factor` equal to `upsample_kernel_size`.

But PR#56 changes the `nn.UpsamplingBilinear2d` init parameter `scale_factor` to be based on `kernel_size` and not `upsample_kernel_size`

This PR fixes this discrepancy.