### PR TITLE
PEP-561

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ keywords = ["PyTorch", "Deep Learning", "Artificial Intelligence", "Meteo-France
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"mfai" = ["py.typed"]
+
 [tool.setuptools_scm]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = {file = ["requirements.txt"]}
 # Package discovery is necessary to set package-data values. See:
 # https://stackoverflow.com/questions/76073605/add-py-typed-as-package-data-with-setuptools-in-pyproject-toml
 [tool.setuptools.packages.find]
-where = ["src"]
+where = ["mfai"]
 
 # Include marker file `py.typed` to respect PEP561 and declare this package as type hinted
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,12 @@ keywords = ["PyTorch", "Deep Learning", "Artificial Intelligence", "Meteo-France
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
+# Package discovery is necessary to set package-data values. See:
+# https://stackoverflow.com/questions/76073605/add-py-typed-as-package-data-with-setuptools-in-pyproject-toml
 [tool.setuptools.packages.find]
 where = ["src"]
 
+# Include marker file `py.typed` to respect PEP561 and declare this package as type hinted
 [tool.setuptools.package-data]
 "mfai" = ["py.typed"]
 


### PR DESCRIPTION
- Related Issue: https://github.com/meteofrance/mfai/issues/40
- Related documentation: https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information
- Related exemple: https://stackoverflow.com/questions/76073605/add-py-typed-as-package-data-with-setuptools-in-pyproject-toml

PEP 561 specifies the necessity of creating a `py.typed` marker file to declare a package as type hinted. Once declared as such, external tools such as mypy will see `mfai`'s type hints as available.