### PR TITLE
Ruff F401 unused imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ Homepage = "https://github.com/meteofrance/mfai"
 
 [tool.ruff.lint]
 select = ["I"]  # I = isort
+extend-select = ["F401"]  # F401 = unused-import
 
 [tool.mypy]
 # [mypy configuration file doc](https://mypy.readthedocs.io/en/stable/config_file.html#confval-exclude)


### PR DESCRIPTION
Add the `F401` rule for unused imports to the ruff config.