### PR TITLE
Add multi token resnet50 + fix cross attention usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
       - deeplabv3/deeplabv3+
       - halfunet
       - unet/customunet
+      - Resnet50, with a specific last stage to output multiple tokens (for MLM)
     - Vision Transformers:
       - segformer
       - swinunetr
@@ -22,10 +23,10 @@
     - Graph Neural Networks:
       - HiLAM
       - GraphLAM
-    - Large Language Models:
+    - Large Language Models (LLMs):
       - GPT2 (classical and cross attention version)
       - LLama2
-    - Multimodal Language Models:
+    - Multimodal Language Models (MLMs):
       - A custom Fuyu inspired model
       - A custom model combining a Resnet50 vision encoder with a cross attention GPT2
     - Vision Language Models:
@@ -66,7 +67,8 @@ Currently we support the following neural network architectures:
 | [DeepLabV3Plus](mfai/pytorch/models/deeplabv3.py#L1) | [arxiv link](https://arxiv.org/abs/1802.02611) | (Batch, features, Height, Width)    | Yes | As a very large receptive field versus U-Net, Half-Unet, ... | Front Detection, Nowcasting |
 | [HalfUNet](mfai/pytorch/models/half_unet.py#L1) | [researchgate link](https://www.researchgate.net/publication/361186968_Half-UNet_A_Simplified_U-Net_Architecture_for_Medical_Image_Segmentation) | (Batch, features, Height, Width)    | Yes | In prod/oper on [Espresso](https://www.mdpi.com/2674-0494/2/4/25) V2 with 128 filters and standard conv blocks instead of ghost | Satellite channels to rain estimation |
 | [UNet](mfai/pytorch/models/unet.py#L1) | [arxiv link](https://arxiv.org/pdf/1505.04597.pdf) | (Batch, features, Height, Width)    | Yes | Vanilla U-Net | Radar image cleaning |
-| [CustomUNet](mfai/pytorch/models/unet.py#L1) | [arxiv link](https://arxiv.org/pdf/1505.04597.pdf) | (Batch, features, Height, Width)    | Yes | U-Net like architecture with a variety of resnet encoder choices | Radar image cleaning
+| [CustomUNet](mfai/pytorch/models/unet.py#L1) | [arxiv link](https://arxiv.org/pdf/1505.04597.pdf) | (Batch, features, Height, Width)    | Yes | U-Net like architecture with a variety of resnet encoder choices | Radar image cleaning |
+| [custom Resnet50](mfai/pytorch/models/resnet.py#L230) | [arxiv link](https://arxiv.org/pdf/1512.03385) | (Batch, features, Height, Width)    | Yes | A slightly customised Resnet50 outputing (batch, num_tokens, embed_dim) for multimodal LM weather/image encoding | Weather + text to text in MLMs |
 
 
 ## Vision Transformers

--- a/mfai/pytorch/models/llms/__init__.py
+++ b/mfai/pytorch/models/llms/__init__.py
@@ -268,9 +268,17 @@ class CrossAttentionTransformerBlock(nn.Module):
 
     def __init__(self, settings: CrossAttGPT2Settings) -> None:
         super().__init__()
-        self.att = MultiHeadCrossAttentionPySDPA(
+        self.x_att = MultiHeadCrossAttentionPySDPA(
             d_in_q=settings.emb_dim,
             d_in_kv=settings.emb_dim,
+            d_out=settings.emb_dim,
+            context_length=settings.context_length,
+            num_heads=settings.n_heads,
+            dropout=settings.drop_rate,
+            qkv_bias=settings.qkv_bias,
+        )
+        self.att = MultiHeadAttentionPySDPA(
+            d_in=settings.emb_dim,
             d_out=settings.emb_dim,
             context_length=settings.context_length,
             num_heads=settings.n_heads,
@@ -286,7 +294,12 @@ class CrossAttentionTransformerBlock(nn.Module):
         # Shortcut connection for attention block
         shortcut = x_q
         x_q = self.norm1(x_q)
-        x = self.att(x_q, x_kv)  # Shape [batch_size, num_tokens, emb_size]
+
+        x_q = self.att(x_q)
+        x_q += shortcut
+        shortcut = x_q
+
+        x = self.x_att(x_q, x_kv)  # Shape [batch_size, num_tokens, emb_size]
         x = self.drop_shortcut(x)
         x = x + shortcut  # Add the original input back
 
@@ -389,15 +402,10 @@ class CrossAttentionGPT2(nn.Module):
         self.drop_emb = nn.Dropout(settings.drop_rate)
 
         # Build the transformer blocks, every nth block includes a cross attention block
-        trf_blocks: list[TransformerBlock | nn.Sequential] = []
+        trf_blocks: list[TransformerBlock | CrossAttentionTransformerBlock] = []
         for i in range(settings.n_layers):
             if i % settings.x_att_ratio == 0:
-                trf_blocks.append(
-                    nn.Sequential(
-                        TransformerBlock(settings),
-                        CrossAttentionTransformerBlock(settings),
-                    )
-                )
+                trf_blocks.append(CrossAttentionTransformerBlock(settings))
             else:
                 trf_blocks.append(TransformerBlock(settings))
         self.trf_blocks = nn.Sequential(*trf_blocks)
@@ -424,14 +432,9 @@ class CrossAttentionGPT2(nn.Module):
         x = self.embed_tokens(token_ids)
         x = self.drop_emb(x)
         for b in self.trf_blocks:
-            if isinstance(b, nn.Sequential):
-                for bb in b:
-                    if isinstance(bb, CrossAttentionTransformerBlock):
-                        # If the block is a cross attention block, we pass the vision inputs
-                        x = bb(x, vision_inputs)
-                    else:
-                        x = bb(x)
-
+            if isinstance(b, CrossAttentionTransformerBlock):
+                # If the block is a cross attention block, we pass the vision inputs
+                x = b(x, vision_inputs)
             else:
                 x = b(x)
 

--- a/mfai/pytorch/models/llms/__init__.py
+++ b/mfai/pytorch/models/llms/__init__.py
@@ -391,7 +391,7 @@ class CrossAttentionGPT2(nn.Module):
         # Build the transformer blocks, every nth block includes a cross attention block
         trf_blocks: list[TransformerBlock | nn.Sequential] = []
         for i in range(settings.n_layers):
-            if i % settings.x_att_ratio == 0 and i != 0:
+            if i % settings.x_att_ratio == 0:
                 trf_blocks.append(
                     nn.Sequential(
                         TransformerBlock(settings),

--- a/mfai/pytorch/models/llms/multimodal.py
+++ b/mfai/pytorch/models/llms/multimodal.py
@@ -307,7 +307,7 @@ class XAttMultiModalLMSettings:
         10,
     )
     x_att_ratio: int = 4  # Cross attention layer ratio
-    num_tokens_vision: int = 32  # Number of vision tokens
+    num_tokens_vision: int = 64  # Number of vision/weather tokens
 
 
 class XAttMultiModalLM(FreezeMLMMixin, nn.Module):

--- a/mfai/pytorch/models/llms/multimodal.py
+++ b/mfai/pytorch/models/llms/multimodal.py
@@ -307,7 +307,7 @@ class XAttMultiModalLMSettings:
         10,
     )
     x_att_ratio: int = 4  # Cross attention layer ratio
-    num_tokens_vision: int = 64  # Number of vision/weather tokens
+    num_tokens_vision: int = 32  # Number of vision/weather tokens
 
 
 class XAttMultiModalLM(FreezeMLMMixin, nn.Module):

--- a/mfai/pytorch/models/resnet.py
+++ b/mfai/pytorch/models/resnet.py
@@ -224,7 +224,7 @@ class ResNet50MLMSettings:
     encoder_depth: int = 5
     encoder_weights: bool = False
     encoder_stride: int = 32
-    num_tokens: int = 32 # number of tokens for the MLM vision encoder
+    num_tokens: int = 32  # number of tokens for the MLM vision encoder
 
 
 class ResNet50MLM(torch.nn.Module):
@@ -232,6 +232,7 @@ class ResNet50MLM(torch.nn.Module):
     A ResNet50 model adapted for Multi-Modal Language Models (MLM).
     This model outputs a sequence of feature vectors instead of a single classification output.
     """
+
     settings_kls = ResNet50MLMSettings
 
     def __init__(
@@ -253,7 +254,7 @@ class ResNet50MLM(torch.nn.Module):
         # For details, see:
         # https://github.com/aladdinpersson/Machine-Learning-Collection/blob/master/ML/Pytorch/CNN_architectures/pytorch_resnet.py
         self.avgpool = torch.nn.AdaptiveAvgPool2d((1, 1))
-        self.fc = torch.nn.Linear(512 * 4, num_classes* settings.num_tokens)
+        self.fc = torch.nn.Linear(512 * 4, num_classes * settings.num_tokens)
         self.num_classes = num_classes
         self.settings = settings
         self.num_channels = num_channels
@@ -263,5 +264,5 @@ class ResNet50MLM(torch.nn.Module):
         y_hat = self.avgpool(y_hat)
         y_hat = y_hat.reshape(y_hat.shape[0], -1)
         y_hat = self.fc(y_hat)
-        # batch, num_tokens, features = num_classes = embed_dim
+        # batch, num_tokens, features = num_classes = embed_dim
         return y_hat.reshape(y_hat.shape[0], self.settings.num_tokens, -1)

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -230,7 +230,7 @@ def test_xatt_multimodal() -> None:
     decoded_text = tokenizer.decode(token_ids_out.squeeze(0).tolist())
     assert (
         decoded_text
-        == "Sustine et abstineHO Dol Astros Verd illuminating ni Rak insights rewrite Slot"
+        == "Sustine et abstine seventy885laugh IsaiahJustк closesdeterminationikhtical"
     )
     model.freeze_llm()
     model.freeze_vision()

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -230,7 +230,7 @@ def test_xatt_multimodal() -> None:
     decoded_text = tokenizer.decode(token_ids_out.squeeze(0).tolist())
     assert (
         decoded_text
-        == "Sustine et abstinemath touredigma doct subpEventuallyodon feelzek grab"
+        == "Sustine et abstine enforcedOriginally MoriAbsashes Deckeritudes048 Revelations originals"
     )
     model.freeze_llm()
     model.freeze_vision()

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -230,7 +230,7 @@ def test_xatt_multimodal() -> None:
     decoded_text = tokenizer.decode(token_ids_out.squeeze(0).tolist())
     assert (
         decoded_text
-        == "Sustine et abstinevictgp pure ojer payoff Standing Neo pled disciplines"
+        == "Sustine et abstineHO Dol Astros Verd illuminating ni Rak insights rewrite Slot"
     )
     model.freeze_llm()
     model.freeze_vision()

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -230,7 +230,7 @@ def test_xatt_multimodal() -> None:
     decoded_text = tokenizer.decode(token_ids_out.squeeze(0).tolist())
     assert (
         decoded_text
-        == "Sustine et abstine seventy885laugh IsaiahJustк closesdeterminationikhtical"
+        == "Sustine et abstinemath touredigma doct subpEventuallyodon feelzek grab"
     )
     model.freeze_llm()
     model.freeze_vision()


### PR DESCRIPTION
* Adds a new Resnet50 dedicated to multimodal LM it outputs (Batch, num_tokens, embed_dim) instead of (batch, embed_dim)
* Makes sure we inject vision/weather token at the first block and then every nth block
* Integrates it to our Cross Attention Multimodal model
* This PR also fixes the way we use cross attention to match Raschka's blog

First results on BMR are encouraging:

![image](https://github.com/user-attachments/assets/84675ead-d8c6-4aa1-8d05-ec29b0c7e63e)

The cross attention fix implements that:
![image](https://github.com/user-attachments/assets/e395d0a2-2382-4f67-b9da-d12b99d532f9)

