### PR TITLE
Fix resnet50mlm norm

### DIFF
--- a/mfai/pytorch/models/llms/multimodal.py
+++ b/mfai/pytorch/models/llms/multimodal.py
@@ -253,10 +253,10 @@ class MultiModalLM(FreezeMLMMixin, nn.Module):
             # resnet50mlm already outputs an extra token dim
             if isinstance(self.vision_encoder, ResNet50):
                 vis_embeds = vis_embeds.unsqueeze(1)
-            
+
             # Normalize the output along embedding dimension
             vis_embeds = vis_embeds / vis_embeds.norm(dim=2, keepdim=True)
-        
+
         else:
             raise ValueError(
                 f"Unknown vision encoder: {self.settings.vision_encoder}. Use 'linear' or 'resnet50'."

--- a/mfai/pytorch/models/llms/multimodal.py
+++ b/mfai/pytorch/models/llms/multimodal.py
@@ -250,13 +250,13 @@ class MultiModalLM(FreezeMLMMixin, nn.Module):
             # Resnet50 encoder
             vis_embeds = self.vision_encoder(new_tensor)
 
-            # Normalize the output
-            vis_embeds = vis_embeds / vis_embeds.norm(dim=1, keepdim=True)
-
             # resnet50mlm already outputs an extra token dim
             if isinstance(self.vision_encoder, ResNet50):
                 vis_embeds = vis_embeds.unsqueeze(1)
-
+            
+            # Normalize the output along embedding dimension
+            vis_embeds = vis_embeds / vis_embeds.norm(dim=2, keepdim=True)
+        
         else:
             raise ValueError(
                 f"Unknown vision encoder: {self.settings.vision_encoder}. Use 'linear' or 'resnet50'."

--- a/mfai/pytorch/models/llms/multimodal.py
+++ b/mfai/pytorch/models/llms/multimodal.py
@@ -365,5 +365,5 @@ class XAttMultiModalLM(FreezeMLMMixin, nn.Module):
         vis_embeds = self.vision_encoder(new_tensor)
 
         # Normalize the output
-        vis_embeds = vis_embeds / vis_embeds.norm(dim=1, keepdim=True)
+        vis_embeds = vis_embeds / vis_embeds.norm(dim=2, keepdim=True)
         return self.backend(token_ids, vis_embeds)


### PR DESCRIPTION
When I added the Resnet50MLM I did not update the norm stage which was previously (classical resnet50) working on the embedding dimension. This PR fixes this and makes sure a Resnet50MLM with one token yields same results as a classicla Resnet50.