### PR TITLE
Adds Linear patch Projector and vit to Cross Attention MLM

### DIFF
--- a/mfai/pytorch/models/llms/cross_attention.py
+++ b/mfai/pytorch/models/llms/cross_attention.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict, dataclass
+from typing import Literal
 
-import einops
+import torch
 from dataclasses_json import dataclass_json
 from torch import Tensor, nn
 
@@ -9,6 +10,11 @@ from mfai.pytorch.models.llms.gpt2 import CrossAttentionGPT2
 from mfai.pytorch.models.resnet import (
     ResNet50MLM,
     ResNet50MLMSettings,
+)
+from mfai.pytorch.models.vit import VitEncoder, ViTEncoderSettings
+from mfai.pytorch.models.weather_projector import (
+    WeatherProjector,
+    WeatherProjectorSettings,
 )
 from mfai.pytorch.namedtensor import NamedTensor
 
@@ -33,7 +39,19 @@ class XAttMultiModalLMSettings:
         10,
     )
     x_att_ratio: int = 4  # Cross attention layer ratio
-    num_tokens_vision: int = 32  # Number of vision/weather tokens
+    resnet_num_tokens: int = 32  # Number of vision/weather tokens
+    # absolute positional embedding for the vision encoder
+    resnet_pos_embedding: bool = False
+
+    # mlp output for the vision encoder
+    resnet_mlp_output: bool = False
+
+    vision_encoder: Literal["resnet50", "linear", "vit"] = "linear"
+
+    # layer norm visual/weather embeddings
+    layer_norm_vis: bool = True
+
+    patch_size: int | tuple[int, int] = 8
 
 
 class XAttMultiModalLM(FreezeMLMMixin, nn.Module):
@@ -62,29 +80,75 @@ class XAttMultiModalLM(FreezeMLMMixin, nn.Module):
             vocab_size=vocab_size,
         )
 
-        # Initialize our resnet50 vision encoder
-        num_channels_viz = (
-            settings.vision_input_shape[2] * settings.vision_input_shape[3]
-        )
-        self.vision_encoder = ResNet50MLM(
-            num_channels=num_channels_viz,
-            num_classes=settings.emb_dim,
-            settings=ResNet50MLMSettings(num_tokens=settings.num_tokens_vision),
-        )
+        self.vision_encoder: WeatherProjector | ResNet50MLM | VitEncoder
+
+        if self.settings.vision_encoder == "linear":
+            input_dims = (
+                settings.vision_input_shape[0],
+                settings.vision_input_shape[1],
+                settings.vision_input_shape[-1],
+            )
+            s = WeatherProjectorSettings(
+                input_dims=input_dims,
+                embedding_dim=self.settings.emb_dim,
+                patch_size=self.settings.patch_size,
+            )
+            self.vision_encoder = WeatherProjector(settings=s)
+
+        elif self.settings.vision_encoder == "resnet50":
+            self.vision_encoder = ResNet50MLM(
+                num_channels=settings.vision_input_shape[3],
+                num_classes=settings.emb_dim,
+                settings=ResNet50MLMSettings(
+                    num_tokens=settings.resnet_num_tokens,
+                    pos_embedding=settings.resnet_pos_embedding,
+                    mlp_output=settings.resnet_mlp_output,
+                ),
+            )
+        elif self.settings.vision_encoder == "vit":
+            # Initialize the ViT encoder, we have one input channel per feature per timestep
+            self.vision_encoder = VitEncoder(
+                in_channels=settings.vision_input_shape[-1],
+                out_channels=settings.emb_dim,
+                settings=ViTEncoderSettings(
+                    emb_dim=settings.emb_dim,
+                    transformer_dropout=settings.drop_rate,
+                    emb_dropout=settings.drop_rate,
+                    autopad_enabled=True,
+                    patch_size=self.settings.patch_size,
+                ),
+                input_shape=settings.vision_input_shape[:2],
+            )
+
+        else:
+            raise ValueError(
+                f"Unknown vision encoder: {self.settings.vision_encoder}. Use 'linear', 'vit' or 'resnet50'."
+            )
+
+        if settings.layer_norm_vis:
+            self.norm_or_ident: nn.Identity | nn.LayerNorm = nn.LayerNorm(
+                self.settings.emb_dim
+            )
+        else:
+            self.norm_or_ident = nn.Identity()
 
     @property
     def context_length(self) -> int:
         return self.backend.context_length
 
     def forward(self, token_ids: Tensor, vision_input: NamedTensor) -> Tensor:
-        # Reshape the vision input
-        new_tensor = einops.rearrange(
-            vision_input.tensor,
-            "batch lat lon timestep features -> batch (timestep features) lat lon",
-        )
+        vis_timesteps_embeds = []
 
-        vis_embeds = self.vision_encoder(new_tensor)
+        for timestep_nt in vision_input.iter_dim("timestep"):
+            # batch, lat, lon, features
+            # rearrange to batch, features, lat, lon
+            timestep_nt.rearrange_("batch lat lon features -> batch features lat lon")
+
+            vis_timesteps_embeds.append(self.vision_encoder(timestep_nt.tensor))
+        vis_embeds = torch.cat(vis_timesteps_embeds, dim=1)
 
         # Normalize the output
-        vis_embeds = vis_embeds / vis_embeds.norm(dim=2, keepdim=True)
+        if self.settings.layer_norm_vis:
+            vis_embeds = self.norm_or_ident(vis_embeds)
+
         return self.backend(token_ids, vis_embeds)

--- a/mfai/pytorch/models/llms/fuyu.py
+++ b/mfai/pytorch/models/llms/fuyu.py
@@ -1,5 +1,4 @@
 from dataclasses import asdict, dataclass
-from pathlib import Path
 from typing import Literal
 
 import torch
@@ -51,8 +50,6 @@ class FuyuSettings:
     # choice of vision encoder
     # "resnet50", "linear"
     vision_encoder: Literal["resnet50", "linear", "vit"] = "linear"
-    # Optional checkpoint path for the resnet encoder
-    resnet_checkpoint: None | Path = None
 
     # number of tokens for ResNet50 encoder
     resnet_num_tokens: int = 32

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -160,7 +160,26 @@ def test_multimodal_with_pretrained_clip() -> None:
     clip.save_vision_encoder(path_checkpoint)
 
 
-def test_xatt_multimodal() -> None:
+@pytest.mark.parametrize(
+    "vision_encoder, target_text",
+    [
+        (
+            "linear",
+            "Sustine et abstine Kissinger Dire thee visitation au LSDcontin nutrition Mecca skewed",
+        ),
+        (
+            "resnet50",
+            "Sustine et abstine Decl Ng playersolithic starving Wilhelm Unreal 207UP Sav",
+        ),
+        (
+            "vit",
+            "Sustine et abstinedriving begurtle truth converted enrichment humiliatingjee Hallsdeal",
+        ),
+    ],
+)
+def test_xatt_multimodal(
+    vision_encoder: Literal["linear", "resnet50", "vit"], target_text: str
+) -> None:
     torch.manual_seed(666)
     vision_input_shape = (128, 128, 2, 1)
     settings = XAttMultiModalLMSettings(
@@ -170,6 +189,7 @@ def test_xatt_multimodal() -> None:
         emb_dim=32,
         context_length=32,
         x_att_ratio=1,
+        vision_encoder=vision_encoder,
     )
     tokenizer = GPT2Tokenizer()
     model = XAttMultiModalLM(settings=settings, vocab_size=tokenizer.vocab_size)
@@ -192,10 +212,7 @@ def test_xatt_multimodal() -> None:
         vision_input=vision_input,
     )
     decoded_text = tokenizer.decode(token_ids_out.squeeze(0).tolist())
-    assert (
-        decoded_text
-        == "Sustine et abstine enforcedOriginally MoriAbsashes Deckeritudes048 Revelations originals"
-    )
+    assert decoded_text == target_text
     model.freeze_llm()
     model.freeze_vision()
     model.unfreeze_llm()


### PR DESCRIPTION
* Harmonize fuyu and Cross attention settings
* Adds Linear and Vit to available image encoders for Cross attention
* Removes deprecated resnet checkpoint setting from Fuyu settings
* Adds unit test for vit and linear