### PR TITLE
add kwargs to export_to_onnx function

### DIFF
--- a/mfai/pytorch/__init__.py
+++ b/mfai/pytorch/__init__.py
@@ -28,7 +28,7 @@ def export_to_onnx(
     model: nn.Module,
     sample: Tensor | tuple[Any, ...],
     filepath: Path | str,
-    **kwargs: dict[str, Any],
+    **kwargs: Any,
 ) -> None:
     """
     Exports a model to ONNX format.


### PR DESCRIPTION
- add `kwargs` to `export_to_onnx()`. These feature allow the user to give some extra arguments to the `torch.onnx.export()`