### PR TITLE
Keep test artifacts out of the project root

### DIFF
--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+import yaml
 from lightning.pytorch.cli import ArgsType, LightningArgumentParser, LightningCLI
 
 from mfai.pytorch.dummy_dataset import DummyMultiModalDataModule
@@ -31,10 +34,23 @@ def cli_main(args: ArgsType = None) -> None:
     cli.trainer.fit(cli.model, datamodule=cli.datamodule)
 
 
-def test_clip_training() -> None:
+def test_clip_training(tmp_path: Path) -> None:
+    config = yaml.safe_load(
+        (Path(__file__).parents[1] / "mfai/config/clip.yaml").read_text()
+    )
+    config["trainer"]["default_root_dir"] = str(tmp_path)
+    for callback in config["trainer"].get("callbacks", []):
+        if callback.get("class_path") == "lightning.pytorch.callbacks.ModelCheckpoint":
+            callback.setdefault("init_args", {})["dirpath"] = str(
+                tmp_path / "checkpoints"
+            )
+
+    config_path = tmp_path / "clip.yaml"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+
     cli_main(
         [
-            "--config=mfai/config/clip.yaml",
+            f"--config={config_path}",
             "--trainer.limit_train_batches=3",
             "--trainer.limit_val_batches=3",
             "--trainer.limit_test_batches=3",

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -1,9 +1,11 @@
 import tempfile
+from pathlib import Path
 from typing import Literal
 
 import lightning.pytorch as L
 import pytest
 import torch
+import yaml
 from lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint
 from lightning.pytorch.cli import ArgsType, LightningCLI
 from lightning.pytorch.loggers import TensorBoardLogger
@@ -74,7 +76,31 @@ def cli_main(args: ArgsType = None) -> None:
     cli.trainer.fit(cli.model, datamodule=cli.datamodule)
 
 
-def test_cli() -> None:
+def _write_lightning_config(
+    source_config: Path,
+    destination: Path,
+    *,
+    root_dir: Path,
+    checkpoint_dir: Path | None = None,
+    log_dir: Path | None = None,
+) -> Path:
+    config = yaml.safe_load(source_config.read_text())
+    trainer_config = config.setdefault("trainer", {})
+    trainer_config["default_root_dir"] = str(root_dir)
+
+    if log_dir is not None and isinstance(trainer_config.get("logger"), dict):
+        trainer_config["logger"].setdefault("init_args", {})["save_dir"] = str(log_dir)
+
+    if checkpoint_dir is not None:
+        for callback in trainer_config.get("callbacks", []):
+            if callback.get("class_path") == "lightning.pytorch.callbacks.ModelCheckpoint":
+                callback.setdefault("init_args", {})["dirpath"] = str(checkpoint_dir)
+
+    destination.write_text(yaml.safe_dump(config, sort_keys=False))
+    return destination
+
+
+def test_cli(tmp_path: Path) -> None:
     cli_main(
         [
             "--model.model=Segformer",
@@ -85,12 +111,21 @@ def test_cli() -> None:
             "--model.model.input_shape=[64, 64]",
             "--optimizer=AdamW",
             "--trainer.fast_dev_run=True",
+            f"--trainer.default_root_dir={tmp_path}",
         ]
     )
 
 
-def test_cli_with_config_file() -> None:
-    cli_main(["--config=mfai/config/cli_fit_test.yaml", "--trainer.fast_dev_run=True"])
+def test_cli_with_config_file(tmp_path: Path) -> None:
+    config_path = _write_lightning_config(
+        Path(__file__).parents[1] / "mfai/config/cli_fit_test.yaml",
+        tmp_path / "cli_fit_test.yaml",
+        root_dir=tmp_path,
+        checkpoint_dir=tmp_path / "checkpoints",
+        log_dir=tmp_path / "logs",
+    )
+
+    cli_main([f"--config={config_path}", "--trainer.fast_dev_run=True"])
 
 
 def test_dgmr_lightningmodule() -> None:

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -140,12 +140,12 @@ def test_multimodal_llm(
         model.unfreeze_vision()
 
 
-def test_multimodal_with_pretrained_clip() -> None:
+def test_multimodal_with_pretrained_clip(tmp_path: Path) -> None:
     torch.manual_seed(666)
     embed_dim = 32
     vision_input_shape = (128, 128, 2, 1)
     num_channels: int = vision_input_shape[2] * vision_input_shape[3]
-    path_checkpoint = Path("checkpoint.tar")
+    path_checkpoint = tmp_path / "checkpoint.tar"
 
     # Setup the CLIP model
     resnet_clip = ResNet50(


### PR DESCRIPTION
## Summary
- redirect the Lightning CLI test runs in `tests/test_lightning.py` into `tmp_path`
- write the CLIP training checkpoint output under `tmp_path` in `tests/test_clip.py`
- write the standalone `checkpoint.tar` artifact under `tmp_path` in `tests/test_multimodal_lm.py`

## Why
Running the test suite was leaving root-relative artifacts behind:
- the config-backed Lightning test path could create a `logs/` tree
- the CLIP Lightning config could emit a `.ckpt` file when logger output was disabled
- the pretrained CLIP test wrote `checkpoint.tar` in the repo root

This keeps those writes scoped to pytest's temporary directory while preserving the test coverage.

## Verification
- `python3 -m py_compile tests/test_lightning.py tests/test_clip.py tests/test_multimodal_lm.py`
- `git diff --check`

I did not run the targeted Lightning pytest cases in this environment because `lightning` is not installed here, and bootstrapping it in a fresh venv pulled a full new `torch` stack rather than reusing the host environment.

Closes #149