### PR TITLE
fix: Fixing SSL certificate issue with pip

### DIFF
--- a/Dockerfile.mf
+++ b/Dockerfile.mf
@@ -2,6 +2,7 @@ FROM python:3.10-slim
 
 ARG INJECT_MF_CERT
 COPY mf.crt /usr/local/share/ca-certificates/mf.crt
+RUN export PIP_CERT=/usr/local/share/ca-certificates/mf.crt
 RUN ( test $INJECT_MF_CERT -eq 1 && update-ca-certificates ) || echo "MF certificate not injected"
 ARG REQUESTS_CA_BUNDLE
 ARG CURL_CA_BUNDLE


### PR DESCRIPTION
Fixing this error raised by pip when trying to use pip :

```py
Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:1017)'))) - skipping
```
Rseolved by :
`lespilettec@0656283725a9:~/mfai$ export PIP_CERT=/usr/local/share/ca-certificates/mf.cr`