### PR TITLE
Dgmr speed up `Generator`

### DIFF
--- a/mfai/pytorch/lightning_modules/gan_dgmr.py
+++ b/mfai/pytorch/lightning_modules/gan_dgmr.py
@@ -226,8 +226,8 @@ class DGMRLightningModule(LightningModule):
         future_images_nt.rearrange_(
             "batch time height width features -> batch time features height width"
         )
-        images = images_nt["rain"].float()
-        future_images = future_images_nt["rain"].float()
+        images: Tensor = images_nt["rain"]
+        future_images: Tensor = future_images_nt["rain"]
 
         real_sequence = torch.cat([images, future_images], dim=1)
 

--- a/mfai/pytorch/models/gan_dgmr/blocks.py
+++ b/mfai/pytorch/models/gan_dgmr/blocks.py
@@ -526,10 +526,13 @@ class LatentConditioningStack(torch.nn.Module):
                 f"Height and width of input tensor must be divisible by 32. Got {x.shape}."
             )
 
-        # Independent draws from Normal distribution
+        # Independent draws from Normal distribution. Shape: (self.input_channels, height // 32, width // 32, 1)
         z = self.distribution.sample((self.input_channels, height // 32, width // 32))
+        # self.distribution.sample returns a float32 tensor, we change it to match the desired dtype
+        z = z.type_as(x)
+
         # Batch is at end for some reason, reshape
-        z = torch.permute(z, (3, 0, 1, 2)).type_as(x)
+        z = torch.permute(z, (3, 0, 1, 2))
 
         # 3x3 Convolution
         z = self.conv_3x3(z)

--- a/mfai/pytorch/models/gan_dgmr/blocks.py
+++ b/mfai/pytorch/models/gan_dgmr/blocks.py
@@ -145,7 +145,7 @@ class UpsampleGBlock(torch.nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         """Apply the forward function."""
-        # Spectrally nsormalized 1x1 convolution
+        # Spectrally normalized 1x1 convolution
         sc = self.upsample(x)
         sc = self.conv_1x1(sc)
 

--- a/mfai/pytorch/models/gan_dgmr/generators.py
+++ b/mfai/pytorch/models/gan_dgmr/generators.py
@@ -150,46 +150,54 @@ class Sampler(torch.nn.Module):
             forecast_steps-length output of images for future timesteps
 
         """
-        # Iterate through each forecast step
-        # Initialize with conditioning state for first one, output for second one
-        init_states = conditioning_states
+        batch_size, _, _, _ = conditioning_states[0].shape
+
         # Expand latent dim to match batch size
         latent_dim = einops.repeat(
-            latent_dim, "b c h w -> (repeat b) c h w", repeat=init_states[0].shape[0]
+            latent_dim,
+            "b c h w -> t (repeat b) c h w",
+            repeat=batch_size,
+            t=self.forecast_steps,
         )
-        hidden_states = [latent_dim] * self.forecast_steps
 
         # Layer 4 (bottom most)
-        hidden_states = self.convGRU1(hidden_states, init_states[3])
-        hidden_states = [self.gru_conv_1x1(h) for h in hidden_states]
-        hidden_states = [self.g1(h) for h in hidden_states]
-        hidden_states = [self.up_g1(h) for h in hidden_states]
+        hidden_states: Tensor = self.convGRU1(latent_dim, conditioning_states[3])
+        hidden_states = einops.rearrange(hidden_states, "t b c h w -> (t b) c h w")
+        hidden_states = self.up_g1(self.g1(self.gru_conv_1x1(hidden_states)))
+        hidden_states = einops.rearrange(
+            hidden_states, "(t b) c h w -> t b c h w", t=self.forecast_steps
+        )
 
         # Layer 3.
-        hidden_states = self.convGRU2(hidden_states, init_states[2])
-        hidden_states = [self.gru_conv_1x1_2(h) for h in hidden_states]
-        hidden_states = [self.g2(h) for h in hidden_states]
-        hidden_states = [self.up_g2(h) for h in hidden_states]
+        hidden_states = self.convGRU2(hidden_states, conditioning_states[2])
+        hidden_states = einops.rearrange(hidden_states, "t b c h w -> (t b) c h w")
+        hidden_states = self.up_g2(self.g2(self.gru_conv_1x1_2(hidden_states)))
+        hidden_states = einops.rearrange(
+            hidden_states, "(t b) c h w -> t b c h w", t=self.forecast_steps
+        )
 
         # Layer 2.
-        hidden_states = self.convGRU3(hidden_states, init_states[1])
-        hidden_states = [self.gru_conv_1x1_3(h) for h in hidden_states]
-        hidden_states = [self.g3(h) for h in hidden_states]
-        hidden_states = [self.up_g3(h) for h in hidden_states]
+        hidden_states = self.convGRU3(hidden_states, conditioning_states[1])
+        hidden_states = einops.rearrange(hidden_states, "t b c h w -> (t b) c h w")
+        hidden_states = self.up_g3(self.g3(self.gru_conv_1x1_3(hidden_states)))
+        hidden_states = einops.rearrange(
+            hidden_states, "(t b) c h w -> t b c h w", t=self.forecast_steps
+        )
 
         # Layer 1 (top-most).
-        hidden_states = self.convGRU4(hidden_states, init_states[0])
-        hidden_states = [self.gru_conv_1x1_4(h) for h in hidden_states]
-        hidden_states = [self.g4(h) for h in hidden_states]
-        hidden_states = [self.up_g4(h) for h in hidden_states]
+        hidden_states = self.convGRU4(hidden_states, conditioning_states[0])
+        hidden_states = einops.rearrange(hidden_states, "t b c h w -> (t b) c h w")
+        hidden_states = self.up_g4(self.g4(self.gru_conv_1x1_4(hidden_states)))
 
         # Output layer.
-        hidden_states = [F.relu(self.bn(h)) for h in hidden_states]
-        hidden_states = [self.conv_1x1(h) for h in hidden_states]
-        hidden_states = [self.depth2space(h) for h in hidden_states]
+        hidden_states = F.relu(self.bn(hidden_states))
+        hidden_states = self.conv_1x1(hidden_states)
+        hidden_states = self.depth2space(hidden_states)
 
         # Convert forecasts to a torch Tensor
-        forecasts = torch.stack(hidden_states, dim=1)
+        forecasts = einops.rearrange(
+            hidden_states, "(t b) c h w -> b t c h w", t=self.forecast_steps
+        ).contiguous()
         return forecasts
 
 

--- a/mfai/pytorch/models/gan_dgmr/layers/attention.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/attention.py
@@ -80,8 +80,10 @@ class AttentionLayer(torch.nn.Module):
         attention_list = []
         for b in range(x.shape[0]):
             # Apply to each in batch
-            attention_list.append(attention_einsum(query[b], key[b], value[b]))
+            att = attention_einsum(query[b], key[b], value[b])
+            attention_list.append(att)
         attention = torch.stack(attention_list, dim=0)
         attention = self.gamma * self.last_conv(attention)
         # Residual connection.
-        return attention + x
+        output = (attention + x).type_as(x)
+        return output

--- a/mfai/pytorch/models/gan_dgmr/layers/attention.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/attention.py
@@ -80,8 +80,9 @@ class AttentionLayer(torch.nn.Module):
         attention_list = []
         for b in range(x.shape[0]):
             # Apply to each in batch
-            att = attention_einsum(query[b], key[b], value[b])
-            attention_list.append(att)
+            attention_list.append(
+                attention_einsum(query[b], key[b], value[b])
+            )
         attention = torch.stack(attention_list, dim=0)
         attention = self.gamma * self.last_conv(attention)
         # Residual connection.

--- a/mfai/pytorch/models/gan_dgmr/layers/attention.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/attention.py
@@ -80,9 +80,7 @@ class AttentionLayer(torch.nn.Module):
         attention_list = []
         for b in range(x.shape[0]):
             # Apply to each in batch
-            attention_list.append(
-                attention_einsum(query[b], key[b], value[b])
-            )
+            attention_list.append(attention_einsum(query[b], key[b], value[b]))
         attention = torch.stack(attention_list, dim=0)
         attention = self.gamma * self.last_conv(attention)
         # Residual connection.

--- a/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
@@ -56,16 +56,16 @@ class ConvGRUCell(torch.nn.Module):
             eps=sn_eps,
         )
 
-    def forward(self, x: Tensor, prev_state: Tensor) -> tuple[Tensor, Tensor]:
+    def forward(self, x: Tensor, prev_state: Tensor) -> Tensor:
         """
         Conv GRU forward, returning the current + new state.
 
         Args:
-            x: Input tensor
+            x: input tensor of shape (B, input_channels, H, W).
             prev_state: Previous state
 
         Returns:
-            New tensor plus the new state
+            output of the convGRU, tensor of shape (B, output_channels, H, W).
 
         """
         # Concatenate the inputs and previous state along the channel axis.
@@ -83,9 +83,7 @@ class ConvGRUCell(torch.nn.Module):
         # Gate the cell and state / outputs.
         c = F.relu(self.output_conv(gated_input))
         out = update_gate * prev_state + (1.0 - update_gate) * c
-        new_state = out
-
-        return out, new_state
+        return out
 
 
 class ConvGRU(torch.nn.Module):
@@ -102,13 +100,18 @@ class ConvGRU(torch.nn.Module):
         super().__init__()
         self.cell = ConvGRUCell(input_channels, output_channels, kernel_size, sn_eps)
 
-    def forward(self, x: list[Tensor], hidden_state: Tensor = None) -> Tensor:
-        """Apply the forward function on each cell prior to returning it as a stack."""
+    def forward(self, x: Tensor, hidden_state: Tensor = None) -> Tensor:
+        """Apply the forward function on each cell prior to returning it as a stack.
+
+        Args:
+            x: tensor from the conditionning stack or from the previous ConvGRU. (timesteps, B, input_channels, H, W)
+            hidden_state: tensor from the latent conditionning stack. (B, latent_channels, H, W)
+        """
         output_list = []
-        for step in range(len(x)):
+        for step in x:  # Iterate over the timestep dimension
             # Compute current timestep
-            output, hidden_state = self.cell(x[step], hidden_state)
-            output_list.append(output)
+            hidden_state = self.cell(step, hidden_state)
+            output_list.append(hidden_state)
         # Stack outputs to return as tensor
         outputs = torch.stack(output_list, dim=0)
         return outputs

--- a/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
@@ -101,7 +101,7 @@ class ConvGRU(torch.nn.Module):
         self.output_channels = output_channels
         self.cell = ConvGRUCell(input_channels, output_channels, kernel_size, sn_eps)
 
-    def forward(self, x: Tensor, hidden_state: Tensor = None) -> Tensor:
+    def forward(self, x: Tensor, hidden_state: Tensor) -> Tensor:
         """Apply the forward function on each cell prior to returning it as a stack.
 
         Args:

--- a/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
@@ -98,6 +98,7 @@ class ConvGRU(torch.nn.Module):
     ) -> None:
         """Initialize the convolution layer."""
         super().__init__()
+        self.output_channels = output_channels
         self.cell = ConvGRUCell(input_channels, output_channels, kernel_size, sn_eps)
 
     def forward(self, x: Tensor, hidden_state: Tensor = None) -> Tensor:
@@ -107,11 +108,19 @@ class ConvGRU(torch.nn.Module):
             x: tensor from the conditionning stack or from the previous ConvGRU. (timesteps, B, input_channels, H, W)
             hidden_state: tensor from the latent conditionning stack. (B, latent_channels, H, W)
         """
-        output_list = []
-        for step in x:  # Iterate over the timestep dimension
+        timesteps, batch_size, _, height, width = x.shape
+        outputs = torch.empty(
+            timesteps,
+            batch_size,
+            self.output_channels,
+            height,
+            width,
+            device=x.device,
+            dtype=x.dtype,
+            layout=x.layout,
+        )
+        for i, step in enumerate(x):  # Iterate over the timestep dimension
             # Compute current timestep
             hidden_state = self.cell(step, hidden_state)
-            output_list.append(hidden_state)
-        # Stack outputs to return as tensor
-        outputs = torch.stack(output_list, dim=0)
+            outputs[i] = hidden_state
         return outputs

--- a/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
@@ -61,11 +61,11 @@ class ConvGRUCell(torch.nn.Module):
         Conv GRU forward, returning the current + new state.
 
         Args:
-            x: input tensor of shape (B, input_channels, H, W).
-            prev_state: Previous state
+            x: Input tensor of shape (B, input_channels, H, W).
+           prev_state: Previous state
 
         Returns:
-            output of the convGRU, tensor of shape (B, output_channels, H, W).
+            Tensor: Output of the convGRU, tensor of shape (B, output_channels, H, W).
 
         """
         # Concatenate the inputs and previous state along the channel axis.

--- a/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
@@ -105,8 +105,8 @@ class ConvGRU(torch.nn.Module):
         """Apply the forward function on each cell prior to returning it as a stack.
 
         Args:
-            x: tensor from the conditionning stack or from the previous ConvGRU. (timesteps, B, input_channels, H, W)
-            hidden_state: tensor from the latent conditionning stack. (B, latent_channels, H, W)
+            x: Tensor from the conditionning stack or from the previous ConvGRU. (timesteps, B, input_channels, H, W)
+            hidden_state: Tensor from the latent conditionning stack. (B, latent_channels, H, W)
         """
         timesteps, batch_size, _, height, width = x.shape
         outputs = torch.empty(

--- a/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
+++ b/mfai/pytorch/models/gan_dgmr/layers/conv_gru.py
@@ -58,11 +58,13 @@ class ConvGRUCell(torch.nn.Module):
 
     def forward(self, x: Tensor, prev_state: Tensor) -> Tensor:
         """
-        Conv GRU forward, returning the current + new state.
+        Conv GRU forward, returning the current state.
+        The sum of the 2 channels dimensions shoud be equal to `input_channels`,
+        ie. C1 + C2 = input_channels.
 
         Args:
-            x: Input tensor of shape (B, input_channels, H, W).
-           prev_state: Previous state
+            x: Input tensor of shape (B, C1, H, W).
+            prev_state: Previous state, tensor of shape (B, C2, H, W).
 
         Returns:
             Tensor: Output of the convGRU, tensor of shape (B, output_channels, H, W).

--- a/mfai/pytorch/transforms.py
+++ b/mfai/pytorch/transforms.py
@@ -110,7 +110,7 @@ class DimensionSubSampler(nn.Module):
         """
         Args:
             dim_name: name of the name tensor dimension to subsample
-            leadtimes_to_keep: list of indexes to be kept in the given dimension.
+            idx_to_keep: list of indexes to be kept in the given dimension.
         """
         super().__init__()
         self.lead_times_indices = torch.tensor(idx_to_keep)
@@ -172,7 +172,7 @@ class MeanDimensionSubsampler(nn.Module):
         """
         Args:
             dim_name: Name of the dimension to subsample.
-            leadtimes_to_keep: List of list of indexes to meaned in the given dimension.
+            idx_to_be_meaned: List of list of indexes to meaned in the given dimension.
         """
         super().__init__()
         self.dim_name = dim_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ docs = [
 dev = [
   "pytest==8.3.4",
   "pytest-cov==6.0.0",
-  "ruff==0.8.1",
+  "ruff==0.15.9",
   "mypy==1.15.0",
   "types-tabulate>=0.9.0",
   "types-tensorflow==2.18.0.20251008",

--- a/tests/test_model_dgmr_gan.py
+++ b/tests/test_model_dgmr_gan.py
@@ -97,9 +97,9 @@ def test_context_conditioning_stack() -> None:
     assert out[1].size() == (2, 192, 16, 16)
     assert out[2].size() == (2, 384, 8, 8)
     assert out[3].size() == (2, 768, 4, 4)
-    assert not all(
-        torch.isnan(out[i]).any() for i in range(len(out))
-    ), "Output included NaNs"
+    assert not all(torch.isnan(out[i]).any() for i in range(len(out))), (
+        "Output included NaNs"
+    )
 
 
 def test_temporal_discriminator() -> None:

--- a/tests/test_model_dgmr_gan.py
+++ b/tests/test_model_dgmr_gan.py
@@ -2,7 +2,6 @@
 
 from typing import Literal
 
-import einops
 import torch
 import torch.nn.functional as F
 
@@ -48,7 +47,8 @@ def test_conv_gru_cell() -> None:
         kernel_size=3,
     )
     x = torch.rand((2, 768, 32, 32))
-    out, _ = model(x, torch.rand((2, 384, 32, 32)))
+    prev_state = torch.rand((2, 384, 32, 32))
+    out = model(x, prev_state)
     y = torch.rand((2, 384, 32, 32))
     loss = F.mse_loss(y, out)
     loss.backward()
@@ -65,7 +65,7 @@ def test_conv_gru() -> None:
     init_states = [torch.rand((2, 384, 32, 32)) for _ in range(4)]
     # Expand latent dim to match batch size
     x = torch.rand((2, 768, 32, 32))
-    hidden_states = [x] * 18
+    hidden_states = x.repeat(18, 1, 1, 1, 1)
     out = model(hidden_states, init_states[3])
     y = torch.rand((18, 2, 384, 32, 32))
     loss = F.mse_loss(y, out)
@@ -161,103 +161,12 @@ def test_sampler() -> None:
     x = torch.rand((2, 4, 1, 256, 256))
     with torch.no_grad():
         latent_dim = latent_stack(x)
-        assert not torch.isnan(latent_dim).any()
-        init_states = conditioning_stack(x)
-        assert not all(
-            torch.isnan(init_states[i]).any() for i in range(len(init_states))
-        )
-        # Expand latent dim to match batch size
-        latent_dim = einops.repeat(
-            latent_dim, "b c h w -> (repeat b) c h w", repeat=init_states[0].shape[0]
-        )
-        assert not torch.isnan(latent_dim).any()
-        hidden_states = [latent_dim] * forecast_steps
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = sampler.convGRU1(hidden_states, init_states[3])
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.gru_conv_1x1(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.g1(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.up_g1(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        # Layer 3.
-        hidden_states = sampler.convGRU2(hidden_states, init_states[2])
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.gru_conv_1x1_2(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.g2(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.up_g2(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
 
-        # Layer 2.
-        hidden_states = sampler.convGRU3(hidden_states, init_states[1])
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.gru_conv_1x1_3(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.g3(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.up_g3(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
+        conditioning_states = conditioning_stack(x)
 
-        # Layer 1 (top-most).
-        hidden_states = sampler.convGRU4(hidden_states, init_states[0])
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.gru_conv_1x1_4(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.g4(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.up_g4(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-
-        # Output layer.
-        hidden_states = [F.relu(sampler.bn(h)) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.conv_1x1(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
-        hidden_states = [sampler.depth2space(h) for h in hidden_states]
-        assert not all(
-            torch.isnan(hidden_states[i]).any() for i in range(len(hidden_states))
-        )
+        out = sampler(conditioning_states, latent_dim)
+        assert not torch.isnan(out).any()
+        assert out.size() == (2, forecast_steps, 1, 256, 256)
 
 
 def test_generator() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -446,14 +446,16 @@ def test_model_attributes(model_class: ModelABC) -> None:
     We check that ALL our models have the required attributes
     settings_kls and model_type.
     """
-    assert (
-        hasattr(model_class, "model_type")
-        and isinstance(model_class.model_type, ModelType)
-    ), f"Model implementation {model_class} is missing attribute 'model_type' of type ModelType"
-    assert (
-        hasattr(model_class, "settings_kls")
-        and dataclasses.is_dataclass(model_class.settings_kls)
-    ), f"Model implementation {model_class} is missing dataclass attribute 'settings_kls'"
+    assert hasattr(model_class, "model_type") and isinstance(
+        model_class.model_type, ModelType
+    ), (
+        f"Model implementation {model_class} is missing attribute 'model_type' of type ModelType"
+    )
+    assert hasattr(model_class, "settings_kls") and dataclasses.is_dataclass(
+        model_class.settings_kls
+    ), (
+        f"Model implementation {model_class} is missing dataclass attribute 'settings_kls'"
+    )
 
 
 def test_IdentityModel() -> None:


### PR DESCRIPTION
- dynamically change the `dtype` of the tensors to reduce RAM memory
- move `timesteps` to `batch size` dimension to speed up the `Sampler()`
- create `torch.empty` tensor in `ConvGRU()` to speed up
- fix some docstring