### PR TITLE
<dgmr> Module forward take mask as optional argument

### DIFF
--- a/mfai/pytorch/lightning_modules/gan_dgmr.py
+++ b/mfai/pytorch/lightning_modules/gan_dgmr.py
@@ -16,6 +16,7 @@ is modified for multiple satellite channels.
 from typing import Any, Literal
 
 import torch
+from einops import repeat
 from lightning import LightningModule
 from torch import Tensor
 
@@ -138,25 +139,37 @@ class DGMRLightningModule(LightningModule):
         # Important: This property activates manual optimization.
         self.automatic_optimization = False
 
-    def forward(self, x: NamedTensor) -> NamedTensor:
-        """Apply the generator to the tensor."""
+    def forward(self, x: NamedTensor, mask: Tensor = None) -> NamedTensor:
+        """Apply the generator to the tensor.
+
+        Args:
+            x (NamedTensor): The past observations. `NamedTensor` of shape (B T H W C) with a feature 'rain'.
+            mask (Tensor): Whether to put nan on the prediction. `Tensor` of shape (B H W). If True, replace the
+                predicted vaue by `nan`. Default value is None.
+
+        Returns:
+            the NamedTensor that contains the prediction made by the DGMR model.
+                `NamedTensor` of shape (B T H W C) with a feature 'rain'.
+        """
         x_copy = x.clone()  # to avoid modifying the original tensor
         x_copy.rearrange_(
             "batch time height width features -> batch time features height width"
         )
         x_rain = x_copy["rain"].float()
 
-        y_hat_rain = self.generator(x_rain)  # Apply model
+        y_hat: Tensor = self.generator(x_rain)  # Apply model
 
-        # Create future radar mask by repeating last input radar mask:
-        mask = torch.cat(
-            [x_copy["mask"][:, -1:] for _ in range(y_hat_rain.shape[1])], dim=1
-        )
-        y_hat = NamedTensor.new_like(torch.cat([y_hat_rain, mask], dim=2), x_copy)
-        y_hat.rearrange_(
+        # Put nan where mask is equal to 0
+        if mask is not None:
+            # Create future radar mask by repeating last input radar mask:
+            mask = repeat(mask, "b h w -> b t c h w", t=y_hat.shape[1], c=1)
+            y_hat = torch.where(mask, float("nan"), y_hat)
+
+        y_hat_nt = NamedTensor.new_like(y_hat, x_copy)
+        y_hat_nt.rearrange_(
             "batch time features height width -> batch time height width features"
         )
-        return y_hat
+        return y_hat_nt
 
     def discriminator_step(
         self,

--- a/mfai/pytorch/lightning_modules/gan_dgmr.py
+++ b/mfai/pytorch/lightning_modules/gan_dgmr.py
@@ -144,8 +144,8 @@ class DGMRLightningModule(LightningModule):
 
         Args:
             x (NamedTensor): The past observations. `NamedTensor` of shape (B T H W C) with a feature 'rain'.
-            mask (Tensor): Whether to put nan on the prediction. `Tensor` of shape (B H W). If True, replace the
-                predicted vaue by `nan`. Default value is None.
+            mask (Tensor): Whether to put nan on the prediction, outside of the radar range. 
+               Boolean `Tensor` of shape (B H W). If True, replace the predicted value by `nan`. Default value is None.
 
         Returns:
             the NamedTensor that contains the prediction made by the DGMR model.

--- a/mfai/pytorch/lightning_modules/gan_dgmr.py
+++ b/mfai/pytorch/lightning_modules/gan_dgmr.py
@@ -144,7 +144,7 @@ class DGMRLightningModule(LightningModule):
 
         Args:
             x (NamedTensor): The past observations. `NamedTensor` of shape (B T H W C) with a feature 'rain'.
-            mask (Tensor): Whether to put nan on the prediction, outside of the radar range. 
+            mask (Tensor): Whether to put nan on the prediction, outside of the radar range.
                Boolean `Tensor` of shape (B H W). If True, replace the predicted value by `nan`. Default value is None.
 
         Returns:

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -7,6 +7,7 @@ import torch
 from lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint
 from lightning.pytorch.cli import ArgsType, LightningCLI
 from lightning.pytorch.loggers import TensorBoardLogger
+from torch import Tensor
 
 from mfai.pytorch.dummy_dataset import DummyDataModule
 from mfai.pytorch.lightning_modules import SegmentationLightningModule
@@ -14,6 +15,7 @@ from mfai.pytorch.lightning_modules.gan_dgmr import DGMRLightningModule
 from mfai.pytorch.models.gan_dgmr import Discriminator, Generator
 from mfai.pytorch.models.unet import UNet
 from mfai.pytorch.namedtensor import NamedTensor
+
 
 @pytest.mark.parametrize(
     "config",

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -15,7 +15,6 @@ from mfai.pytorch.models.gan_dgmr import Discriminator, Generator
 from mfai.pytorch.models.unet import UNet
 from mfai.pytorch.namedtensor import NamedTensor
 
-
 @pytest.mark.parametrize(
     "config",
     [
@@ -125,12 +124,22 @@ def test_dgmr_lightningmodule() -> None:
     assert isinstance(module.discriminator, Discriminator)
 
     nt_input = NamedTensor(
-        torch.randn(2, 4, 128, 128, 2),
+        torch.randn(2, 4, 128, 128, 1),
         ["batch", "time", "height", "width", "features"],
-        ["rain", "mask"],
+        ["rain"],
     )
+    mask = torch.randn(2, 128, 128) > 0.9  # Tensor of boolean
     module.eval()
     with torch.no_grad():
         output = module(nt_input)
+        output_masked = module(nt_input, mask)
+
+    # Testing type and shape of the prediction
     assert isinstance(output, NamedTensor)
-    assert output.tensor.shape == (2, 18, 128, 128, 2)
+    assert output.tensor.shape == (2, 18, 128, 128, 1)
+
+    # Testing type and shape of the masked prediction
+    assert isinstance(output_masked, NamedTensor)
+    assert output_masked.tensor.shape == (2, 18, 128, 128, 1)
+    last_frame: Tensor = output_masked.tensor[0, -1, :, :, 0]
+    assert torch.all(torch.isnan(last_frame) == mask[0])


### PR DESCRIPTION
The mask is removed from the original `NamedTensor` (with keys `rain` and `mask`), but we could still need it in the `forward` pass. So we add it as an optional argument.