### PR TITLE
<requirements> upgrade mlflow to ~=3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "dataclasses-json~=0.6",
   "einops~=0.8",
   "lightning[pytorch-extra]",
-  "mlflow==3.10.*",
+  "mlflow~=3.11",
   "monai==1.5.*",
   "onnx~=1.17.0",
   "onnxruntime~=1.20",


### PR DESCRIPTION
Upgrade `mflow~=3.11` to take advantage of the bug fix for images that were incorrectly loaded in the `MLFlowLogger`.