### PR TITLE
Gpt2 add kv cache

### DIFF
--- a/mfai/pytorch/models/llms/fuyu.py
+++ b/mfai/pytorch/models/llms/fuyu.py
@@ -243,7 +243,7 @@ class Fuyu(FreezeMLMMixin, nn.Module):
         if self.settings.inject_vision_each_stage:
             # Inject vision tokens at each stage
             logits = self.backend.forward_vectors(
-                x, vis_txt_embeds[:, : vis_embeds.shape[1]]
+                x, first_embedding=vis_txt_embeds[:, : vis_embeds.shape[1]]
             )
         else:
             logits = self.backend.forward_vectors(x)

--- a/mfai/pytorch/models/llms/gpt2.py
+++ b/mfai/pytorch/models/llms/gpt2.py
@@ -160,8 +160,17 @@ class MultiHeadAttention(nn.Module):
         # Compute scaled dot-product attention (aka self-attention) with a causal mask
         attn_scores = queries @ keys.transpose(2, 3)  # Dot product for each head
 
-        # Original mask truncated to the number of tokens and converted to boolean
-        mask_bool = self.mask.bool()[:num_tokens, :num_tokens]  # type: ignore[operator]
+        num_tokens_Q = queries.shape[-2]
+        num_tokens_K = keys.shape[-2]
+        if use_cache:
+            mask_bool = self.mask.bool()[
+                self.ptr_current_pos : self.ptr_current_pos + num_tokens_Q,
+                :num_tokens_K,
+            ]
+            self.ptr_current_pos += num_tokens_Q
+        else:
+            # Original mask truncated to the number of tokens and converted to boolean
+            mask_bool = self.mask.bool()[:num_tokens_Q, :num_tokens_K]  # type: ignore[operator]
 
         # Use the mask to fill attention scores
         attn_scores.masked_fill_(mask_bool, -torch.inf)
@@ -177,6 +186,10 @@ class MultiHeadAttention(nn.Module):
         context_vec = self.out_proj(context_vec)  # optional projection
 
         return context_vec
+
+    def reset_cache(self):
+        self.cache_k, self.cache_v = None, None
+        self.ptr_current_pos = 0
 
 
 class MultiHeadAttentionPySDPA(nn.Module):
@@ -410,9 +423,10 @@ class GPT2(nn.Module):
         self.pos_emb = nn.Embedding(settings.context_length, settings.emb_dim)
         self.drop_emb = nn.Dropout(settings.drop_rate)
 
-        self.trf_blocks = nn.Sequential(
-            *[TransformerBlock(settings) for _ in range(settings.n_layers)]
+        self.trf_blocks = nn.ModuleList(
+            [TransformerBlock(settings) for _ in range(settings.n_layers)]
         )
+        self.current_pos = 0  # Used for KV cache
 
         self.final_norm = LayerNorm(settings.emb_dim)
         self.out_head = nn.Linear(settings.emb_dim, vocab_size, bias=False)
@@ -554,12 +568,12 @@ class GPT2(nn.Module):
         x = self.drop_emb(embeddings)
 
         if first_embedding is not None:
-            for block in self.trf_blocks:
+            for blk in self.trf_blocks:
                 # replace the first token of x by the corresponding first_embedding
                 x = torch.cat(
                     [first_embedding, x[:, first_embedding.shape[1] :, :]], dim=1
                 )
-                x = block(x, use_cache=use_cache)
+                x = blk(x, use_cache=use_cache)
         else:
             for blk in self.trf_blocks:
                 x = blk(x, use_cache=use_cache)
@@ -611,7 +625,8 @@ class GPT2(nn.Module):
             Failure to call this method between independent sequences may result
             in incorrect attention patterns due to stale cached values.
         """
-        self.cache_k, self.cache_v = None, None
+        for blk in self.trf_blocks:
+            blk.att.reset_cache()
         self.current_pos = 0
 
 

--- a/mfai/pytorch/models/llms/gpt2.py
+++ b/mfai/pytorch/models/llms/gpt2.py
@@ -6,7 +6,7 @@ https://github.com/rasbt/LLMs-from-scratch/.
 import typing
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Sequential, Union
+from typing import Literal, Union
 
 import numpy as np
 import torch
@@ -427,8 +427,8 @@ class GPT2(nn.Module):
         self.pos_emb = nn.Embedding(settings.context_length, settings.emb_dim)
         self.drop_emb = nn.Dropout(settings.drop_rate)
 
-        self.trf_blocks: Sequential[TransformerBlock] = nn.ModuleList(
-            [TransformerBlock(settings) for _ in range(settings.n_layers)]
+        self.trf_blocks = nn.Sequential(
+            *[TransformerBlock(settings) for _ in range(settings.n_layers)]
         )
         self.current_pos = 0  # Used for KV cache
 
@@ -630,6 +630,7 @@ class GPT2(nn.Module):
             in incorrect attention patterns due to stale cached values.
         """
         for blk in self.trf_blocks:
+            assert isinstance(blk.att, MultiHeadAttention)
             blk.att.reset_cache()
         self.current_pos = 0
 

--- a/mfai/pytorch/models/llms/gpt2.py
+++ b/mfai/pytorch/models/llms/gpt2.py
@@ -103,18 +103,54 @@ class MultiHeadAttention(nn.Module):
             "mask", torch.triu(torch.ones(context_length, context_length), diagonal=1)
         )
 
-    def forward(self, x: Tensor) -> Tensor:
+        # To use KV cache
+        self.register_buffer("cache_k", None, persistent=False)
+        self.register_buffer("cache_v", None, persistent=False)
+
+    def forward(self, x: Tensor, use_cache: bool) -> Tensor:
+        """Computes the multi-head attention output for the given input tensor.
+
+        This method applies query, key, and value projections, computes scaled
+        dot-product attention with a causal mask, and combines the results across
+        all attention heads. Optionally supports caching of keys and values for
+        efficient autoregressive generation.
+
+        Args:
+            x (Tensor): Input tensor of shape `(batch_size, num_tokens, d_in)`
+                        representing the sequence of tokens to attend over.
+            use_cache (bool): If True, uses cached keys and values for incremental decoding.
+
+        Returns:
+            Tensor: Output tensor of shape `(batch_size, num_tokens, d_out)`
+                    containing the attended representations.
+
+        Note:
+            When `use_cache=True`, the method updates internal caches (`cache_k`, `cache_v`)
+            and should be used in conjunction with `reset_cache()` between independent
+            sequences to avoid cross-sequence contamination.
+
+        """
         b, num_tokens, _ = x.shape
 
-        keys = self.W_key(x)  # Shape: (b, num_tokens, d_out)
+        keys_new = self.W_key(x)  # Shape: (b, num_tokens, d_out)
         queries = self.W_query(x)
-        values = self.W_value(x)
+        values_new = self.W_value(x)
 
         # We implicitly split the matrix by adding a `num_heads` dimension
         # Unroll last dim: (b, num_tokens, d_out) -> (b, num_tokens, num_heads, head_dim)
-        keys = keys.view(b, num_tokens, self.num_heads, self.head_dim)
-        values = values.view(b, num_tokens, self.num_heads, self.head_dim)
+        keys_new = keys_new.view(b, num_tokens, self.num_heads, self.head_dim)
+        values_new = values_new.view(b, num_tokens, self.num_heads, self.head_dim)
         queries = queries.view(b, num_tokens, self.num_heads, self.head_dim)
+
+        if use_cache:
+            if self.cache_k is None:
+                self.cache_k, self.cache_v = keys_new, values_new
+            else:
+                self.cache_k = torch.cat([self.cache_k, keys_new], dim=1)
+                self.cache_v = torch.cat([self.cache_v, values_new], dim=1)
+            keys, values = self.cache_k, self.cache_v
+        else:
+            keys, values = keys_new, values_new
 
         # Transpose: (b, num_tokens, num_heads, head_dim) -> (b, num_heads, num_tokens, head_dim)
         keys = keys.transpose(1, 2)
@@ -333,11 +369,16 @@ class TransformerBlock(nn.Module):
         self.norm2 = LayerNorm(settings.emb_dim)
         self.drop_shortcut = nn.Dropout(settings.drop_rate)
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: Tensor, use_cache: bool = False) -> Tensor:
         # Shortcut connection for attention block
         shortcut = x
         x = self.norm1(x)
-        x = self.att(x)  # Shape [batch_size, num_tokens, emb_size]
+        if isinstance(self.att, MultiHeadAttention):
+            x = self.att(
+                x, use_cache=use_cache
+            )  # Shape [batch_size, num_tokens, emb_size]
+        else:
+            x = self.att(x)  # Shape [batch_size, num_tokens, emb_size]
         x = self.drop_shortcut(x)
         x = x + shortcut  # Add the original input back
 
@@ -498,7 +539,10 @@ class GPT2(nn.Module):
         self.load_weights_from_dict(params)
 
     def forward_vectors(
-        self, embeddings: Tensor, first_embedding: Union[None, Tensor] = None
+        self,
+        embeddings: Tensor,
+        use_cache: bool,
+        first_embedding: Union[None, Tensor] = None,
     ) -> Tensor:
         """
         Process a batch of embeddings through the model.
@@ -515,14 +559,15 @@ class GPT2(nn.Module):
                 x = torch.cat(
                     [first_embedding, x[:, first_embedding.shape[1] :, :]], dim=1
                 )
-                x = block(x)
+                x = block(x, use_cache=use_cache)
         else:
-            x = self.trf_blocks(x)
+            for blk in self.trf_blocks:
+                x = blk(x, use_cache=use_cache)
         x = self.final_norm(x)
         logits = self.out_head(x)
         return logits
 
-    def embed_tokens(self, tok_ids: Tensor) -> Tensor:
+    def embed_tokens(self, tok_ids: Tensor, use_cache: bool) -> Tensor:
         """
         Embeds and pos encodes tokens.
         """
@@ -532,15 +577,42 @@ class GPT2(nn.Module):
             )
         _, seq_len = tok_ids.shape
         tok_embeds = self.tok_emb(tok_ids)
-        pos_embeds = self.pos_emb(torch.arange(seq_len, device=tok_ids.device))
+
+        if use_cache:
+            pos_ids = torch.arange(
+                self.current_pos,
+                self.current_pos + seq_len,
+                device=tok_ids.device,
+                dtype=torch.long,
+            )
+            self.current_pos += seq_len
+        else:
+            pos_ids = torch.arange(0, seq_len, device=tok_ids.device, dtype=torch.long)
+        pos_embeds = self.pos_emb(pos_ids).unsqueeze(0)
+
         return tok_embeds + pos_embeds  # Shape [batch_size, num_tokens, emb_size]
 
-    def forward(self, tok_ids: Tensor) -> Tensor:
+    def forward(self, tok_ids: Tensor, use_cache: bool = False) -> Tensor:
         tok_ids = tok_ids[
             :, -self.context_length :
         ]  # Keep only the last context_length tokens
-        x = self.embed_tokens(tok_ids)
-        return self.forward_vectors(x)
+        x = self.embed_tokens(tok_ids, use_cache=use_cache)
+        return self.forward_vectors(x, use_cache=use_cache)
+
+    def reset_kv_cache(self) -> None:
+        """Clear the Key-Value cache used for incremental decoding.
+
+        This method must be called between processing independent sequences to
+        prevent cross-sequence contamination in autoregressive generation. After
+        calling this method, the cache will be reset to None and ready for a new
+        sequence.
+
+        Note:
+            Failure to call this method between independent sequences may result
+            in incorrect attention patterns due to stale cached values.
+        """
+        self.cache_k, self.cache_v = None, None
+        self.current_pos = 0
 
 
 @dataclass_json

--- a/mfai/pytorch/models/llms/gpt2.py
+++ b/mfai/pytorch/models/llms/gpt2.py
@@ -6,7 +6,7 @@ https://github.com/rasbt/LLMs-from-scratch/.
 import typing
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal, Sequential, Union
 
 import numpy as np
 import torch
@@ -99,11 +99,14 @@ class MultiHeadAttention(nn.Module):
         self.W_value = nn.Linear(d_in, d_out, bias=qkv_bias)
         self.out_proj = nn.Linear(d_out, d_out)  # Linear layer to combine head outputs
         self.dropout = nn.Dropout(dropout)
+        self.mask: Tensor
         self.register_buffer(
             "mask", torch.triu(torch.ones(context_length, context_length), diagonal=1)
         )
 
         # To use KV cache
+        self.cache_k: Tensor | None
+        self.cache_v: Tensor | None
         self.register_buffer("cache_k", None, persistent=False)
         self.register_buffer("cache_v", None, persistent=False)
 
@@ -132,9 +135,9 @@ class MultiHeadAttention(nn.Module):
         """
         b, num_tokens, _ = x.shape
 
-        keys_new = self.W_key(x)  # Shape: (b, num_tokens, d_out)
-        queries = self.W_query(x)
-        values_new = self.W_value(x)
+        keys_new: Tensor = self.W_key(x)  # Shape: (b, num_tokens, d_out)
+        queries: Tensor = self.W_query(x)
+        values_new: Tensor = self.W_value(x)
 
         # We implicitly split the matrix by adding a `num_heads` dimension
         # Unroll last dim: (b, num_tokens, d_out) -> (b, num_tokens, num_heads, head_dim)
@@ -143,8 +146,9 @@ class MultiHeadAttention(nn.Module):
         queries = queries.view(b, num_tokens, self.num_heads, self.head_dim)
 
         if use_cache:
-            if self.cache_k is None:
-                self.cache_k, self.cache_v = keys_new, values_new
+            if self.cache_k is None or self.cache_v is None:
+                self.cache_k = keys_new
+                self.cache_v = values_new
             else:
                 self.cache_k = torch.cat([self.cache_k, keys_new], dim=1)
                 self.cache_v = torch.cat([self.cache_v, values_new], dim=1)
@@ -170,7 +174,7 @@ class MultiHeadAttention(nn.Module):
             self.ptr_current_pos += num_tokens_Q
         else:
             # Original mask truncated to the number of tokens and converted to boolean
-            mask_bool = self.mask.bool()[:num_tokens_Q, :num_tokens_K]  # type: ignore[operator]
+            mask_bool = self.mask.bool()[:num_tokens_Q, :num_tokens_K]
 
         # Use the mask to fill attention scores
         attn_scores.masked_fill_(mask_bool, -torch.inf)
@@ -187,7 +191,7 @@ class MultiHeadAttention(nn.Module):
 
         return context_vec
 
-    def reset_cache(self):
+    def reset_cache(self) -> None:
         self.cache_k, self.cache_v = None, None
         self.ptr_current_pos = 0
 
@@ -423,7 +427,7 @@ class GPT2(nn.Module):
         self.pos_emb = nn.Embedding(settings.context_length, settings.emb_dim)
         self.drop_emb = nn.Dropout(settings.drop_rate)
 
-        self.trf_blocks = nn.ModuleList(
+        self.trf_blocks: Sequential[TransformerBlock] = nn.ModuleList(
             [TransformerBlock(settings) for _ in range(settings.n_layers)]
         )
         self.current_pos = 0  # Used for KV cache
@@ -555,7 +559,7 @@ class GPT2(nn.Module):
     def forward_vectors(
         self,
         embeddings: Tensor,
-        use_cache: bool,
+        use_cache: bool = False,
         first_embedding: Union[None, Tensor] = None,
     ) -> Tensor:
         """
@@ -581,7 +585,7 @@ class GPT2(nn.Module):
         logits = self.out_head(x)
         return logits
 
-    def embed_tokens(self, tok_ids: Tensor, use_cache: bool) -> Tensor:
+    def embed_tokens(self, tok_ids: Tensor, use_cache: bool = False) -> Tensor:
         """
         Embeds and pos encodes tokens.
         """

--- a/mfai/pytorch/models/llms/gpt2.py
+++ b/mfai/pytorch/models/llms/gpt2.py
@@ -611,6 +611,24 @@ class GPT2(nn.Module):
         return tok_embeds + pos_embeds  # Shape [batch_size, num_tokens, emb_size]
 
     def forward(self, tok_ids: Tensor, use_cache: bool = False) -> Tensor:
+        """Performs the forward pass of the GPT-2 model.
+
+        Args:
+            tok_ids (Tensor): Tensor of token IDs input with shape (batch_size, sequence_length).
+            use_cache (bool, optional): If True, uses attention caching for computational
+                optimization. Defaults to False.
+
+        Returns:
+            Tensor: Model output tensor with shape (batch_size, sequence_length, hidden_size) or
+                    (batch_size, context_length, hidden_size) depending on model dimensions.
+
+        Note:
+            This method truncates the input tokens to keep only the last `context_length` tokens,
+            which limits the input length to a maximum value defined by the model.
+
+            The KV cache implementation is largely inspired by S. Rashka. See
+            https://github.com/rasbt/LLMs-from-scratch/tree/main/ch04/03_kv-cache for more details.
+        """
         tok_ids = tok_ids[
             :, -self.context_length :
         ]  # Keep only the last context_length tokens

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -1,3 +1,4 @@
+import time
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -22,7 +23,7 @@ from mfai.tokenizers import GPT2Tokenizer, LlamaTokenizer, Tokenizer
     [
         (
             partial(GPT2, GPT2Settings()),
-            "Hello, I amisi invincible collided 1500 tenomenotinables thinks republic",
+            "Hello, I am CH commemor scholarly fingerprint oppositethrenClean Bridgewatericidal scalp",
             GPT2Tokenizer(),
         ),
         (
@@ -54,6 +55,44 @@ def test_llms(model_target_tokenizer: tuple[Any, str, Tokenizer]) -> None:
     decoded_text = tokenizer.decode(out.squeeze(0).tolist())
 
     assert decoded_text == target
+
+
+@pytest.mark.parametrize("model_tokenizer", [(GPT2(GPT2Settings()), GPT2Tokenizer())])
+def test_kv_cache(model_tokenizer: tuple[GPT2, GPT2Settings]) -> None:
+    """
+    We check that KV cache implementation is working and a speed-up text generation.
+    """
+    model, tokenizer = model_tokenizer
+    start_context = "Hello, I am"
+    encoded = tokenizer.encode(start_context)
+    encoded_tensor = torch.tensor(encoded).unsqueeze(0)
+
+    start = time.perf_counter()
+    out = generate_text_simple(
+        model=model,
+        idx=encoded_tensor,
+        max_new_tokens=50,
+        context_size=model.context_length,
+        use_cache=False,
+    )
+    end = time.perf_counter()
+    exec_time = end - start
+    decoded_text = tokenizer.decode(out.squeeze(0).tolist())
+
+    start = time.perf_counter()
+    out = generate_text_simple(
+        model=model,
+        idx=encoded_tensor,
+        max_new_tokens=50,
+        context_size=model.context_length,
+        use_cache=True,
+    )
+    end = time.perf_counter()
+    exec_time_with_cache = end - start
+    decoded_text_with_cache = tokenizer.decode(out.squeeze(0).tolist())
+
+    assert exec_time_with_cache < exec_time
+    assert decoded_text == decoded_text_with_cache
 
 
 def test_cross_attention_gpt2() -> None:

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -1,6 +1,6 @@
-from pathlib import Path
 import time
 from functools import partial
+from pathlib import Path
 from typing import Any
 
 import pytest

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 import time
 from functools import partial
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -57,7 +57,9 @@ def test_llms(model_target_tokenizer: tuple[Any, str, Tokenizer]) -> None:
     assert decoded_text == target
 
 
-@pytest.mark.parametrize("model_tokenizer", [(GPT2(GPT2Settings()), GPT2Tokenizer())])
+@pytest.mark.parametrize(
+    "model_tokenizer", [(GPT2(GPT2Settings(attn_tf_compat=True)), GPT2Tokenizer())]
+)
 def test_kv_cache(model_tokenizer: tuple[GPT2, GPT2Settings]) -> None:
     """
     We check that KV cache implementation is working and a speed-up text generation.
@@ -71,7 +73,7 @@ def test_kv_cache(model_tokenizer: tuple[GPT2, GPT2Settings]) -> None:
     out = generate_text_simple(
         model=model,
         idx=encoded_tensor,
-        max_new_tokens=50,
+        max_new_tokens=10,
         context_size=model.context_length,
         use_cache=False,
     )
@@ -83,7 +85,7 @@ def test_kv_cache(model_tokenizer: tuple[GPT2, GPT2Settings]) -> None:
     out = generate_text_simple(
         model=model,
         idx=encoded_tensor,
-        max_new_tokens=50,
+        max_new_tokens=10,
         context_size=model.context_length,
         use_cache=True,
     )
@@ -91,8 +93,8 @@ def test_kv_cache(model_tokenizer: tuple[GPT2, GPT2Settings]) -> None:
     exec_time_with_cache = end - start
     decoded_text_with_cache = tokenizer.decode(out.squeeze(0).tolist())
 
-    assert exec_time_with_cache < exec_time
     assert decoded_text == decoded_text_with_cache
+    assert exec_time_with_cache < exec_time
 
 
 def test_cross_attention_gpt2() -> None:

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -94,16 +94,16 @@ def generate_text_simple(
             "gpt2",
             GPT2Tokenizer(),
             (
-                "Sustine et abstineinipowerful humiliatinggrowingMarcus Items trolls 2009 homophobic 296",
-                "Sustine et abstine lettucerapeUNCHframelsh Capitalism ended 269 initiate Minneapolis",
+                "Sustine et abstineiniumsy cruc validated Lauderdale Tory filib Storiesebook Minutes",
+                "Sustine et abstine itch Su Preston fpsPRES standing overboard Saganshoot EST",
             ),
         ),
         (
             "gpt2",
             LlamaTokenizer(),
             (
-                "Sustine et abstine współ terrestführt fr выполxmlnsполćлы released",
-                "Sustine et abstine Records RET și taililia осоagoggetInstance characteristicApplication",
+                "Sustine et abstine współ terrestführt closeemente virtố Consider wordpress чтобы",
+                "Sustine et abstine ReleasesetText movie województ Klosterająţ‰ anten stri",
             ),
         ),
     ],
@@ -196,15 +196,15 @@ def test_multimodal_with_pretrained_clip() -> None:
     [
         (
             "linear",
-            "Sustine et abstine Declitely string slips auJustice interpret skeletalOEengineering",
+            "Sustine et abstine Decl utmost absurdity Aster chemically 147inglyPATHOEengineering",
         ),
         (
             "resnet50",
-            "Sustine et abstine nowherearationsself bell Schedule Pegasus Alm phosphJew cad",
+            "Sustine et abstine Decl Ng Blakeopus guiIcon vaginaitz revolutionsOEHI",
         ),
         (
             "vit",
-            "Sustine et abstine Decl extrem…immigrant Glen fears yogageriesobjSave",
+            "Sustine et abstine Decl utmostisman camping coron DOM settlersPen endemic cortisol",
         ),
     ],
 )
@@ -291,7 +291,7 @@ def test_fuyu_with_mlp_and_pos_embedding() -> None:
     decoded_text = tokenizer.decode(out.squeeze(0).tolist())
     assert (
         decoded_text
-        == "Sustine et abstine Quartz Assistance popped drains scandal restraint arg suhelpHam"
+        == "Sustine et abstine Quartzinternetmulti AdultgreSQL CapAPP induct condom solitude"
     )
     model.freeze_llm()
     model.unfreeze_llm()
@@ -304,15 +304,15 @@ def test_fuyu_with_mlp_and_pos_embedding() -> None:
     [
         (
             "linear",
-            "Sustine et abstine tests scripted inferred Zy StephPowerborn PROGRAM Minute infectious",
+            "Sustine et abstine tests spreeticket insur Mannyigate destroyerinates camel l",
         ),
         (
             "resnet50",
-            "Sustine et abstine intellig Housing NvidiaBind targets constructing BuffyWithinwings nonexistent",
+            "Sustine et abstine intellig spans manoeuv�� 1850PER 1300。 monumental UAE",
         ),
         (
             "vit",
-            "Sustine et abstine bans applianceERGeatured Strawberry purple doorsteploader Jesus Thailand",
+            "Sustine et abstine reality incorrectly673 Cheng Suggest Detailsricsantically Tourism nonexistent",
         ),
     ],
 )

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Literal, Tuple
+from typing import Any, Literal
 
 import pytest
 import torch
@@ -25,31 +25,40 @@ def generate_text_simple(
     idx: Tensor,
     max_new_tokens: int,
     context_size: int,
+    use_cache: bool = False,
     vision_inputs: None | Tensor | list[Tensor] = None,
 ) -> Tensor:
-    # idx is (B, T) array of indices in the current context
-    for _ in range(max_new_tokens):
-        # Crop current context if it exceeds the supported context size
-        # E.g., if LLM supports only 5 tokens, and the context size is 10
-        # then only the last 5 tokens are used as context
-        idx_cond = idx[:, -context_size:]
 
-        # Get the predictions
-        with torch.no_grad():
+    model.eval()
+    with torch.no_grad():
+        if use_cache:
+            # Init cache with full prompt
+            model.reset_kv_cache()
+
+        # idx is (B, T) array of indices in the current context
+        for _ in range(max_new_tokens):
+            # Crop current context if it exceeds the supported context size
+            # E.g., if LLM supports only 5 tokens, and the context size is 10
+            # then only the last 5 tokens are used as context
+            idx_cond = idx[:, -context_size:]
+
+            kwargs: dict[str, Any] = {}
             if vision_inputs is not None:
-                logits = model(idx_cond, vision_inputs)
-            else:
-                logits = model(idx_cond)
+                kwargs["vision_inputs"] = vision_inputs
+            if use_cache:
+                kwargs["use_cache"] = use_cache
 
-        # Focus only on the last time step
-        # (batch, n_token, vocab_size) becomes (batch, vocab_size)
-        logits = logits[:, -1, :]
+            logits = model(idx_cond, **kwargs)
 
-        # Get the idx of the vocab entry with the highest logits value
-        idx_next = torch.argmax(logits, dim=-1, keepdim=True)  # (batch, 1)
+            # Focus only on the last time step
+            # (batch, n_token, vocab_size) becomes (batch, vocab_size)
+            logits = logits[:, -1, :]
 
-        # Append sampled index to the running sequence
-        idx = torch.cat((idx, idx_next), dim=1)  # (batch, n_tokens+1)
+            # Get the idx of the vocab entry with the highest logits value
+            idx_next = torch.argmax(logits, dim=-1, keepdim=True)  # (batch, 1)
+
+            # Append sampled index to the running sequence
+            idx = torch.cat((idx, idx_next), dim=1)  # (batch, n_tokens+1)
 
     return idx
 
@@ -94,7 +103,7 @@ def generate_text_simple(
 def test_multimodal_llm(
     llm_backend: Literal["llama2", "gpt2", "llama3"],
     tokenizer: GPT2Tokenizer | LlamaTokenizer,
-    expected_text: Tuple[str, str],
+    expected_text: tuple[str, str],
 ) -> None:
     torch.manual_seed(999)
     for force_vision in (False, True):

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -28,37 +28,45 @@ def generate_text_simple(
     use_cache: bool = False,
     vision_inputs: None | Tensor | list[Tensor] = None,
 ) -> Tensor:
+    kwargs: dict[str, Any] = {}
+    if vision_inputs is not None:
+        kwargs["vision_inputs"] = vision_inputs
+    if use_cache:
+        kwargs["use_cache"] = use_cache
 
     model.eval()
     with torch.no_grad():
         if use_cache:
             # Init cache with full prompt
             model.reset_kv_cache()
+            logits = model(idx[:, -context_size:], **kwargs)
 
-        # idx is (B, T) array of indices in the current context
-        for _ in range(max_new_tokens):
-            # Crop current context if it exceeds the supported context size
-            # E.g., if LLM supports only 5 tokens, and the context size is 10
-            # then only the last 5 tokens are used as context
-            idx_cond = idx[:, -context_size:]
+            for _ in range(max_new_tokens):
+                # a) pick the token with the highest log-probability (greedy sampling)
+                next_idx = logits[:, -1].argmax(dim=-1, keepdim=True)
+                # b) append it to the running sequence
+                idx = torch.cat([idx, next_idx], dim=1)
+                # c) feed model only the new token
+                logits = model(next_idx, **kwargs)
 
-            kwargs: dict[str, Any] = {}
-            if vision_inputs is not None:
-                kwargs["vision_inputs"] = vision_inputs
-            if use_cache:
-                kwargs["use_cache"] = use_cache
+        else:
+            # idx is (B, T) array of indices in the current context
+            for _ in range(max_new_tokens):
+                # Crop current context if it exceeds the supported context size
+                # E.g., if LLM supports only 5 tokens, and the context size is 10
+                # then only the last 5 tokens are used as context
+                idx_cond = idx[:, -context_size:]
+                logits = model(idx_cond, **kwargs)
 
-            logits = model(idx_cond, **kwargs)
+                # Focus only on the last time step
+                # (batch, n_token, vocab_size) becomes (batch, vocab_size)
+                logits = logits[:, -1, :]
 
-            # Focus only on the last time step
-            # (batch, n_token, vocab_size) becomes (batch, vocab_size)
-            logits = logits[:, -1, :]
+                # Get the idx of the vocab entry with the highest logits value
+                idx_next = torch.argmax(logits, dim=-1, keepdim=True)  # (batch, 1)
 
-            # Get the idx of the vocab entry with the highest logits value
-            idx_next = torch.argmax(logits, dim=-1, keepdim=True)  # (batch, 1)
-
-            # Append sampled index to the running sequence
-            idx = torch.cat((idx, idx_next), dim=1)  # (batch, n_tokens+1)
+                # Append sampled index to the running sequence
+                idx = torch.cat((idx, idx_next), dim=1)  # (batch, n_tokens+1)
 
     return idx
 

--- a/tests/test_multimodal_lm.py
+++ b/tests/test_multimodal_lm.py
@@ -38,7 +38,7 @@ def generate_text_simple(
     with torch.no_grad():
         if use_cache:
             # Init cache with full prompt
-            model.reset_kv_cache()
+            model.reset_kv_cache()  # type: ignore[operator]
             logits = model(idx[:, -context_size:], **kwargs)
 
             for _ in range(max_new_tokens):


### PR DESCRIPTION
Implementation of the KV cache feature on the `GPT2` model. As there is many ways of "KV caching", we choose the Rashka's implementation: https://github.com/rasbt/LLMs-from-scratch/tree/main/ch04/03_kv-cache

Unit tests ensure that predictions are identical with or without caching and inference is faster when `use_cache=True`