### PR TITLE
Extend mypy verif entire repo during tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Type hinting with mypy on changed files
       if: steps.changed-py-files.outputs.any_changed == 'true'
       run: |
-        mypy ${{ steps.changed-py-files.outputs.all_changed_files }}
+        mypy .
 
     - name: Test with pytest
       if: steps.changed-py-files.outputs.any_changed == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Type hinting with mypy on changed files
       if: steps.changed-py-files.outputs.any_changed == 'true'
       run: |
-        mypy .
+        mypy mfai/ tests/
 
     - name: Test with pytest
       if: steps.changed-py-files.outputs.any_changed == 'true'

--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -10,9 +10,7 @@ import lightning as L
 from lightning.fabric.utilities.exceptions import MisconfigurationException
 from lightning.pytorch.cli import SaveConfigCallback
 from lightning.pytorch.loggers.mlflow import MLFlowLogger
-from mlflow.system_metrics.system_metrics_monitor import (  # type: ignore[import-not-found]
-    SystemMetricsMonitor,
-)
+from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
 from typing_extensions import override
 
 


### PR DESCRIPTION
To extend mypy verifications to the entire repo, and not exclusively to the changed files. This modification ensure that a change in a file `dummy.py` does not impact a second file who imports some functions or classes (`from dummy import MyModel`).

So we run `mypy ` over the entire repo and remove the `# type: ignore[import-not-found]` in `mfai/pytorch/callbacks.py`.