### PR TITLE
<CI> move "Install git" before `actions/checkout`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,10 +44,10 @@ jobs:
       image: python:3.10-slim
 
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Install git  # necessary for the tj-action/changed-py-files
+    - name: Install git  # necessary for the checkout and changed-py-files actions
       run: apt-get update && apt-get install -y git
+
+    - uses: actions/checkout@v4
 
     - name: Gather Python changed files
       id: changed-py-files


### PR DESCRIPTION
The CI fails on "pull" (ie. after the PR is approved):
```
>Run tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a
/usr/bin/docker exec  1daba6821a367e509e73e5cea6efbc839afc95410ac2de768e18cfdfcdaeb331 sh -c "cat /etc/*release | grep ^ID"
>changed-files
  Error: Unable to locate the git repository in the given path: /__w/mfai/mfai.
   Please run actions/checkout before this action (Make sure the 'path' input is correct).
   If you intend to use Github's REST API note that only pull_request* events are supported. Current event is "push".
```

This PR try to fix it by moving `apt install git` before run `actions/checkout`