### PR TITLE
<dgmr> rename 'generation_steps' arg into 'samples_per_input'

### DIFF
--- a/mfai/pytorch/lightning_modules/gan_dgmr.py
+++ b/mfai/pytorch/lightning_modules/gan_dgmr.py
@@ -49,7 +49,7 @@ class DGMRLightningModule(LightningModule):
         beta2: float = 0.999,
         latent_channels: int = 768,
         context_channels: int = 384,
-        generation_steps: int = 6,
+        samples_per_input: int = 6,
         apply_last_relu: bool = False,
         precip_weight_cap: float = 24.0,
         use_attention: bool = True,
@@ -81,7 +81,7 @@ class DGMRLightningModule(LightningModule):
                 reshaped to, input dimension into ConvGRU, also affects the
                 number of channels for other linked inputs/outputs.
             context_channels: Number of context channels (int)
-            generation_steps: Number of generation steps to use in forward pass,
+            samples_per_input: Number of generation steps to use in forward pass,
                 in paper is 6 and the best is chosen for the loss this results
                 in huge amounts of GPU memory though, so less might work better
                 for training.
@@ -105,7 +105,7 @@ class DGMRLightningModule(LightningModule):
         self.beta1 = beta1
         self.beta2 = beta2
         self.grid_lambda = grid_lambda
-        self.generation_steps = generation_steps
+        self.samples_per_input = samples_per_input
 
         # Definition of Loss
         self.grid_regularizer = GridCellLoss(precip_weight_cap=precip_weight_cap)
@@ -260,7 +260,7 @@ class DGMRLightningModule(LightningModule):
             d_opt.step()
 
         predictions: list[Tensor] = [
-            self.generator(images) for _ in range(self.generation_steps)
+            self.generator(images) for _ in range(self.samples_per_input)
         ]
         generator_loss, grid_cell_reg = self.generator_step(
             predictions, images, future_images, real_sequence

--- a/mfai/pytorch/models/gan_dgmr/blocks.py
+++ b/mfai/pytorch/models/gan_dgmr/blocks.py
@@ -70,9 +70,10 @@ class GBlock(torch.nn.Module):
 
     def forward(self, x: Tensor) -> Tensor:
         """Apply the forward function.
-        
+
         Args:
-            x: the Tensor to apply the GBlock on."""
+        x: the Tensor to apply the GBlock on.
+        """
         # Optionally spectrally normalized 1x1 convolution
         if x.shape[1] != self.output_channels:
             sc = self.conv_1x1(x)
@@ -516,13 +517,13 @@ class LatentConditioningStack(torch.nn.Module):
         """Apply convolution, L blocks, and spatial attention module to the input tensor.
 
         Args:
-            x (Tensor): Input tensor with shape (batch_size, channels, height, width) 
-                where height and width must be divisible by 32. The tensor must 
+            x (Tensor): Input tensor with shape (batch_size, channels, height, width)
+                where height and width must be divisible by 32. The tensor must
                 be on the correct device and will be moved to the latent distribution.
 
         Returns:
-            Tensor: Output tensor after processing through convolution, L blocks, and 
-                optional attention module. The output shape depends on the specific 
+            Tensor: Output tensor after processing through convolution, L blocks, and
+                optional attention module. The output shape depends on the specific
                 implementation of the layers but maintains the batch dimension.
 
         Raises:

--- a/mfai/pytorch/models/gan_dgmr/blocks.py
+++ b/mfai/pytorch/models/gan_dgmr/blocks.py
@@ -30,7 +30,7 @@ class GBlock(torch.nn.Module):
             input_channels: Number of input channels
             output_channels: Number of output channels
             conv_type: Type of convolution desired, see satflow/models/utils.py for options
-            spectral_normalized_eps: constrains the spectral norm of the weights.
+            spectral_normalized_eps: epsilon for numerical stability in calculating norms. Default is 1e-4.
 
         """
         super().__init__()
@@ -69,7 +69,10 @@ class GBlock(torch.nn.Module):
         )
 
     def forward(self, x: Tensor) -> Tensor:
-        """Apply the forward function."""
+        """Apply the forward function.
+        
+        Args:
+            x: the Tensor to apply the GBlock on."""
         # Optionally spectrally normalized 1x1 convolution
         if x.shape[1] != self.output_channels:
             sc = self.conv_1x1(x)
@@ -92,8 +95,8 @@ class UpsampleGBlock(torch.nn.Module):
 
     def __init__(
         self,
-        input_channels: int = 12,
-        output_channels: int = 12,
+        input_channels: int,
+        output_channels: int,
         conv_type: Literal["standard", "coord", "3d"] = "standard",
         spectral_normalized_eps: float = 0.0001,
     ) -> None:
@@ -103,8 +106,8 @@ class UpsampleGBlock(torch.nn.Module):
         Args:
             input_channels: Number of input channels.
             output_channels: Number of output channels.
-            conv_type: Type of convolution desired, see satflow/models/utils.py for options.
-            spectral_normalized_eps: constrains the spectral norm of the weights.
+            conv_type: Type of the convolution. Default is 'standard'.
+            spectral_normalized_eps: epsilon for numerical stability in calculating norms. Default is 1e-4.
 
         """
         super().__init__()
@@ -167,8 +170,8 @@ class DBlock(torch.nn.Module):
 
     def __init__(
         self,
-        input_channels: int = 12,
-        output_channels: int = 12,
+        input_channels: int,
+        output_channels: int,
         conv_type: Literal["standard", "coord", "3d"] = "standard",
         first_relu: bool = True,
         keep_same_output: bool = False,
@@ -179,8 +182,8 @@ class DBlock(torch.nn.Module):
         Args:
             input_channels: Number of input channels
             output_channels: Number of output channels
-            conv_type: Convolution type, see satflow/models/utils.py for options
-            first_relu: Whether to have an ReLU before the first 3x3 convolution
+            conv_type: Type of the convolution. Default is 'standard'.
+            first_relu: Whether to have an ReLU before the first 3x3 convolution. Default is 'True'.
             keep_same_output: Whether the output should have the same spatial dimensions
             as input, if False, downscales by 2
 
@@ -510,15 +513,22 @@ class LatentConditioningStack(torch.nn.Module):
         )
 
     def forward(self, x: Tensor) -> Tensor:
-        """
-        Apply convolution, l blocks and spatial attention module to the tensor.
+        """Apply convolution, L blocks, and spatial attention module to the input tensor.
 
         Args:
-            x: tensor on the correct device, to move over the latent distribution
+            x (Tensor): Input tensor with shape (batch_size, channels, height, width) 
+                where height and width must be divisible by 32. The tensor must 
+                be on the correct device and will be moved to the latent distribution.
 
         Returns:
-               tensor
+            Tensor: Output tensor after processing through convolution, L blocks, and 
+                optional attention module. The output shape depends on the specific 
+                implementation of the layers but maintains the batch dimension.
 
+        Raises:
+            ValueError: If the height or width of the input tensor is not divisible by 32.
+                This constraint is required for proper processing through the network's
+                downsampling operations.
         """
         height, width = x.shape[-2], x.shape[-1]
         if (height % 32 != 0) or (width % 32 != 0):

--- a/mfai/pytorch/models/gan_dgmr/blocks.py
+++ b/mfai/pytorch/models/gan_dgmr/blocks.py
@@ -30,7 +30,7 @@ class GBlock(torch.nn.Module):
             input_channels: Number of input channels
             output_channels: Number of output channels
             conv_type: Type of convolution desired, see satflow/models/utils.py for options
-            spectral_normalized_eps: epsilon for numerical stability in calculating norms. Default is 1e-4.
+            spectral_normalized_eps: Epsilon for numerical stability in calculating norms. Default is 1e-4.
 
         """
         super().__init__()
@@ -72,7 +72,7 @@ class GBlock(torch.nn.Module):
         """Apply the forward function.
 
         Args:
-        x: the Tensor to apply the GBlock on.
+            x: The Tensor to apply the GBlock on.
         """
         # Optionally spectrally normalized 1x1 convolution
         if x.shape[1] != self.output_channels:
@@ -108,7 +108,7 @@ class UpsampleGBlock(torch.nn.Module):
             input_channels: Number of input channels.
             output_channels: Number of output channels.
             conv_type: Type of the convolution. Default is 'standard'.
-            spectral_normalized_eps: epsilon for numerical stability in calculating norms. Default is 1e-4.
+            spectral_normalized_eps: Epsilon for numerical stability in calculating norms. Default is 1e-4.
 
         """
         super().__init__()
@@ -517,7 +517,7 @@ class LatentConditioningStack(torch.nn.Module):
         """Apply convolution, L blocks, and spatial attention module to the input tensor.
 
         Args:
-            x (Tensor): Input tensor with shape (batch_size, channels, height, width)
+            x: Input tensor with shape (batch_size, channels, height, width)
                 where height and width must be divisible by 32. The tensor must
                 be on the correct device and will be moved to the latent distribution.
 

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -109,7 +109,7 @@ def test_dgmr_lightningmodule() -> None:
         beta2=0.999,
         latent_channels=768,
         context_channels=384,
-        generation_steps=6,
+        samples_per_input=6,
         precip_weight_cap=24.0,
         use_attention=True,
         temporal_num_layers=3,
@@ -123,7 +123,7 @@ def test_dgmr_lightningmodule() -> None:
     assert module.grid_lambda == 20.0
     assert module.beta1 == 0.0
     assert module.beta2 == 0.999
-    assert module.generation_steps == 6
+    assert module.samples_per_input == 6
     assert isinstance(module.generator, Generator)
     assert isinstance(module.discriminator, Discriminator)
 

--- a/tests/test_model_dgmr_gan.py
+++ b/tests/test_model_dgmr_gan.py
@@ -98,9 +98,9 @@ def test_context_conditioning_stack() -> None:
     assert out[1].size() == (2, 192, 16, 16)
     assert out[2].size() == (2, 384, 8, 8)
     assert out[3].size() == (2, 768, 4, 4)
-    assert not all(
-        torch.isnan(out[i]).any() for i in range(len(out))
-    ), "Output included NaNs"
+    assert not all(torch.isnan(out[i]).any() for i in range(len(out))), (
+        "Output included NaNs"
+    )
 
 
 def test_temporal_discriminator() -> None:

--- a/tests/test_model_dgmr_gan.py
+++ b/tests/test_model_dgmr_gan.py
@@ -20,7 +20,7 @@ from mfai.pytorch.models.gan_dgmr.layers.conv_gru import ConvGRU, ConvGRUCell
 
 
 def test_dblock() -> None:
-    model = DBlock(keep_same_output=True)
+    model = DBlock(12, 12, keep_same_output=True)
     x = torch.rand((2, 12, 128, 128))
     out = model(x)
     y = torch.rand((2, 12, 128, 128))

--- a/tests/test_model_dgmr_gan.py
+++ b/tests/test_model_dgmr_gan.py
@@ -98,9 +98,9 @@ def test_context_conditioning_stack() -> None:
     assert out[1].size() == (2, 192, 16, 16)
     assert out[2].size() == (2, 384, 8, 8)
     assert out[3].size() == (2, 768, 4, 4)
-    assert not all(torch.isnan(out[i]).any() for i in range(len(out))), (
-        "Output included NaNs"
-    )
+    assert not all(
+        torch.isnan(out[i]).any() for i in range(len(out))
+    ), "Output included NaNs"
 
 
 def test_temporal_discriminator() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -446,14 +446,16 @@ def test_model_attributes(model_class: ModelABC) -> None:
     We check that ALL our models have the required attributes
     settings_kls and model_type.
     """
-    assert (
-        hasattr(model_class, "model_type")
-        and isinstance(model_class.model_type, ModelType)
-    ), f"Model implementation {model_class} is missing attribute 'model_type' of type ModelType"
-    assert (
-        hasattr(model_class, "settings_kls")
-        and dataclasses.is_dataclass(model_class.settings_kls)
-    ), f"Model implementation {model_class} is missing dataclass attribute 'settings_kls'"
+    assert hasattr(model_class, "model_type") and isinstance(
+        model_class.model_type, ModelType
+    ), (
+        f"Model implementation {model_class} is missing attribute 'model_type' of type ModelType"
+    )
+    assert hasattr(model_class, "settings_kls") and dataclasses.is_dataclass(
+        model_class.settings_kls
+    ), (
+        f"Model implementation {model_class} is missing dataclass attribute 'settings_kls'"
+    )
 
 
 def test_IdentityModel() -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -446,16 +446,14 @@ def test_model_attributes(model_class: ModelABC) -> None:
     We check that ALL our models have the required attributes
     settings_kls and model_type.
     """
-    assert hasattr(model_class, "model_type") and isinstance(
-        model_class.model_type, ModelType
-    ), (
-        f"Model implementation {model_class} is missing attribute 'model_type' of type ModelType"
-    )
-    assert hasattr(model_class, "settings_kls") and dataclasses.is_dataclass(
-        model_class.settings_kls
-    ), (
-        f"Model implementation {model_class} is missing dataclass attribute 'settings_kls'"
-    )
+    assert (
+        hasattr(model_class, "model_type")
+        and isinstance(model_class.model_type, ModelType)
+    ), f"Model implementation {model_class} is missing attribute 'model_type' of type ModelType"
+    assert (
+        hasattr(model_class, "settings_kls")
+        and dataclasses.is_dataclass(model_class.settings_kls)
+    ), f"Model implementation {model_class} is missing dataclass attribute 'settings_kls'"
 
 
 def test_IdentityModel() -> None:


### PR DESCRIPTION
Renaming `generation_steps` to `samples_per_input` to use the same vocabulary as the DeepMind article.