### PR TITLE
Add dgmr to doc models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,8 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+doc/_build/
+doc/api/
 
 # PyBuilder
 .pybuilder/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.10-slim
 
 # Install project dependencies
-RUN apt -y update && apt -y install git
+RUN apt -y update && apt -y install git make
 WORKDIR /app
 COPY pyproject.toml pyproject.toml
 RUN pip install --upgrade build twine setuptools
-RUN pip install .[llm,dev]
+RUN pip install .[llm,dev,docs]
 
 ADD mfai /app/mfai
 ADD tests /app/tests

--- a/Dockerfile.mf
+++ b/Dockerfile.mf
@@ -9,17 +9,17 @@ ARG CURL_CA_BUNDLE
 
 ENV MY_APT='apt-get -o "Acquire::https::Verify-Peer=false" -o "Acquire::AllowInsecureRepositories=true" -o "Acquire::AllowDowngradeToInsecureRepositories=true" -o "Acquire::https::Verify-Host=false"'
 
-RUN $MY_APT update && $MY_APT install -y curl nano sudo git openssh-server
+RUN $MY_APT update && $MY_APT install -y curl nano sudo git openssh-server make
 
-RUN mkdir -p /run/sshd
-RUN curl -fsSL https://code-server.dev/install.sh | sh
+# RUN mkdir -p /run/sshd
+# RUN curl -fsSL https://code-server.dev/install.sh | sh
 
 # Install project dependencies
 RUN apt -y update && apt -y install git
 WORKDIR /app
 COPY pyproject.toml pyproject.toml
 RUN pip install --upgrade build twine setuptools
-RUN pip install .[llm,dev]
+RUN pip install .[llm,dev,docs]
 
 ARG USERNAME
 ARG GROUPNAME

--- a/doc/generate_rst.py
+++ b/doc/generate_rst.py
@@ -31,7 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # ---------------------------------------------------------------------------
 
 
-def is_subclass_of_names(cls: type, base_names: Sequence[str | list[str]]) -> bool:
+def has_attribute_value(cls: type, base_names: Sequence[str | list[str]]) -> bool:
     """Check if a class inherits from any of the given base class names.
 
     Supports both OR and AND conditions:
@@ -60,7 +60,7 @@ def is_subclass_of_names(cls: type, base_names: Sequence[str | list[str]]) -> bo
     return False
 
 
-def is_attribute_of_name(cls: type, attr: str, value: Any) -> bool:
+def has_attribute_of_name(cls: type, attr: str, value: Any) -> bool:
     if hasattr(cls, attr):
         if getattr(cls, attr) == value:
             return True
@@ -396,7 +396,7 @@ if __name__ == "__main__":
         model_classes: list[str] = sorted(
             get_classes_matching(
                 "mfai.pytorch.models",
-                check_fn=is_attribute_of_name,
+                check_fn=has_attribute_of_name,
                 check_fn_args=["model_type", model_type],
             )
         )
@@ -417,7 +417,7 @@ if __name__ == "__main__":
                 "classes": sorted(
                     get_classes_matching(
                         "mfai.pytorch.losses",
-                        check_fn=is_subclass_of_names,
+                        check_fn=has_attribute_value,
                         check_fn_args=[["Module"]],
                     )
                 ),
@@ -433,7 +433,7 @@ if __name__ == "__main__":
                 "title": "Lightning Modules",
                 "classes": get_classes_matching(
                     "mfai.pytorch.lightning_modules",
-                    check_fn=is_subclass_of_names,
+                    check_fn=has_attribute_value,
                     check_fn_args=[["LightningModule"]],
                 ),
             },
@@ -441,7 +441,7 @@ if __name__ == "__main__":
                 "title": "Callbacks",
                 "classes": get_classes_matching(
                     "mfai.pytorch",
-                    check_fn=is_subclass_of_names,
+                    check_fn=has_attribute_value,
                     check_fn_args=[["Callback"]],
                 ),
             },
@@ -456,7 +456,7 @@ if __name__ == "__main__":
                 "title": "Transforms",
                 "classes": get_classes_matching(
                     "mfai.pytorch.transforms",
-                    check_fn=is_subclass_of_names,
+                    check_fn=has_attribute_value,
                     check_fn_args=[["object"]],
                 ),
             }
@@ -471,7 +471,7 @@ if __name__ == "__main__":
                 "title": "Metrics",
                 "classes": get_classes_matching(
                     "mfai.pytorch.metrics",
-                    check_fn=is_subclass_of_names,
+                    check_fn=has_attribute_value,
                     check_fn_args=[["Metric"]],
                 ),
             }

--- a/doc/generate_rst.py
+++ b/doc/generate_rst.py
@@ -15,11 +15,11 @@ Requires sphinxcontrib-mermaid in conf.py extensions.
 This script is meant to be run before the Sphinx build step, either locally or in CI.
 """
 
-from enum import Enum
 import importlib
 import inspect
 import pkgutil
 import sys
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Generator, Literal, Sequence
 

--- a/doc/generate_rst.py
+++ b/doc/generate_rst.py
@@ -15,6 +15,7 @@ Requires sphinxcontrib-mermaid in conf.py extensions.
 This script is meant to be run before the Sphinx build step, either locally or in CI.
 """
 
+from enum import Enum
 import importlib
 import inspect
 import pkgutil
@@ -59,6 +60,13 @@ def is_subclass_of_names(cls: type, base_names: Sequence[str | list[str]]) -> bo
     return False
 
 
+def is_attribute_of_name(cls: type, attr: str, value: Any) -> bool:
+    if hasattr(cls, attr):
+        if getattr(cls, attr) == value:
+            return True
+    return False
+
+
 def iter_all_modules(package_path: str) -> Generator[str, None, None]:
     """Recursively yield all module names within a given package.
 
@@ -83,7 +91,7 @@ def iter_all_modules(package_path: str) -> Generator[str, None, None]:
 
 def get_classes_matching(
     package_path: str,
-    check_fn: Callable[[Any, Any], bool],
+    check_fn: Callable,
     check_fn_args: Any,
 ) -> list[str]:
     """Find all classes in a package that match the given inheritance conditions.
@@ -358,23 +366,48 @@ def write_rst(
     print(f"Written {output_path} ({len(all_fqns)} classes)")
 
 
+def write_model_rst(model_types: Enum, output_path: Path) -> None:
+    # Write header
+    lines: list[str] = []
+    title = "Models"
+    lines.append(title)
+    lines.append("=" * len(title))
+    lines.append("")
+
+    # Write tree of content
+    lines.append(".. toctree::")
+    lines.append("   :maxdepth: 1")
+    lines.append("")
+    for model_type in model_types:
+        lines.append(f"   models_{model_type.name.lower()}")
+    lines.append("")
+
+    output_path.write_text("\n".join(lines))
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    model_classes: list[str] = sorted(
-        ["mfai.pytorch.models.base.ModelABC"]
-        + get_classes_matching(
-            "mfai.pytorch.models", check_fn=hasattr, check_fn_args=["model_type"]
+    from mfai.pytorch.models import ModelType
+
+    for model_type in ModelType:
+        model_classes: list[str] = sorted(
+            get_classes_matching(
+                "mfai.pytorch.models",
+                check_fn=is_attribute_of_name,
+                check_fn_args=["model_type", model_type],
+            )
         )
-    )
-    write_rst(
-        title="Models",
-        sections=[{"title": "Models", "classes": model_classes}],
-        output_path=Path("doc/api/models.rst"),
-        with_diagrams=True,
-    )
+        write_rst(
+            title=model_type.name.title(),
+            sections=[{"title": model_type.name, "classes": model_classes}],
+            output_path=Path(f"doc/api/models_{model_type.name.lower()}.rst"),
+            with_diagrams=True,
+        )
+
+    write_model_rst(ModelType, output_path=Path("doc/api/models.rst"))
 
     write_rst(
         title="Losses",

--- a/doc/generate_rst.py
+++ b/doc/generate_rst.py
@@ -82,7 +82,9 @@ def iter_all_modules(package_path: str) -> Generator[str, None, None]:
 
 
 def get_classes_matching(
-    package_path: str, base_names: Sequence[str | list[str]]
+    package_path: str,
+    base_names: Sequence[str | list[str]] = None,
+    attribute: str = None,
 ) -> list[str]:
     """Find all classes in a package that match the given inheritance conditions.
 
@@ -97,6 +99,9 @@ def get_classes_matching(
     Returns:
         A list of fully qualified class names (e.g. 'mfai.pytorch.losses.dice.DiceLoss').
     """
+    if not base_names and not attribute:
+        raise ValueError("Please set 'base_names' or 'attribute' argument.")
+
     matches = []
     for module_name in iter_all_modules(package_path):
         try:
@@ -108,8 +113,15 @@ def get_classes_matching(
                 continue
             if getattr(obj, "__module__", None) != module_name:
                 continue
-            if is_subclass_of_names(obj, base_names):
-                matches.append(f"{module_name}.{name}")
+            if base_names and attribute:
+                if is_subclass_of_names(obj, base_names) or hasattr(obj, attribute):
+                    matches.append(f"{module_name}.{name}")
+            elif base_names:
+                if is_subclass_of_names(obj, base_names):
+                    matches.append(f"{module_name}.{name}")
+            else:
+                if hasattr(obj, attribute):
+                    matches.append(f"{module_name}.{name}")
 
     return matches
 
@@ -360,18 +372,13 @@ def write_rst(
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
+    model_classes: list[str] = sorted(
+        ["mfai.pytorch.models.base.ModelABC"]
+        + get_classes_matching("mfai.pytorch.models", attribute="model_type")
+    )
     write_rst(
         title="Models",
-        sections=[
-            {"title": "Models", "classes": ["mfai.pytorch.models.base.ModelABC"]},
-            {
-                "title": "Models",
-                "classes": get_classes_matching(
-                    "mfai.pytorch.models",
-                    [["ModelABC", "Module"], "BaseModel"],
-                ),
-            },
-        ],
+        sections=[{"title": "Models", "classes": model_classes}],
         output_path=Path("doc/api/models.rst"),
         with_diagrams=True,
     )
@@ -381,9 +388,11 @@ if __name__ == "__main__":
         sections=[
             {
                 "title": "Losses",
-                "classes": get_classes_matching(
-                    "mfai.pytorch.losses",
-                    ["Module"],
+                "classes": sorted(
+                    get_classes_matching(
+                        "mfai.pytorch.losses",
+                        ["Module"],
+                    )
                 ),
             }
         ],

--- a/doc/generate_rst.py
+++ b/doc/generate_rst.py
@@ -23,6 +23,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Generator, Literal, Sequence
 
+from mfai.pytorch.models import ModelType
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
@@ -390,8 +392,6 @@ def write_model_rst(model_types: Enum, output_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    from mfai.pytorch.models import ModelType
-
     for model_type in ModelType:
         model_classes: list[str] = sorted(
             get_classes_matching(

--- a/doc/generate_rst.py
+++ b/doc/generate_rst.py
@@ -20,7 +20,7 @@ import inspect
 import pkgutil
 import sys
 from pathlib import Path
-from typing import Any, Generator, Literal, Sequence
+from typing import Any, Callable, Generator, Literal, Sequence
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -83,8 +83,8 @@ def iter_all_modules(package_path: str) -> Generator[str, None, None]:
 
 def get_classes_matching(
     package_path: str,
-    base_names: Sequence[str | list[str]] = None,
-    attribute: str = None,
+    check_fn: Callable[[Any, Any], bool],
+    check_fn_args: Any,
 ) -> list[str]:
     """Find all classes in a package that match the given inheritance conditions.
 
@@ -94,14 +94,12 @@ def get_classes_matching(
     Args:
         package_path: The dotted path of the package to search
             (e.g. 'mfai.pytorch.losses').
-        base_names: Inheritance conditions passed to `is_subclass_of_names`.
+        check_fn: the function used to check if the class is valid.
+        check_fn_args: arguments to pass to the 'check_fn'.
 
     Returns:
         A list of fully qualified class names (e.g. 'mfai.pytorch.losses.dice.DiceLoss').
     """
-    if not base_names and not attribute:
-        raise ValueError("Please set 'base_names' or 'attribute' argument.")
-
     matches = []
     for module_name in iter_all_modules(package_path):
         try:
@@ -113,15 +111,8 @@ def get_classes_matching(
                 continue
             if getattr(obj, "__module__", None) != module_name:
                 continue
-            if base_names and attribute:
-                if is_subclass_of_names(obj, base_names) or hasattr(obj, attribute):
-                    matches.append(f"{module_name}.{name}")
-            elif base_names:
-                if is_subclass_of_names(obj, base_names):
-                    matches.append(f"{module_name}.{name}")
-            else:
-                if hasattr(obj, attribute):
-                    matches.append(f"{module_name}.{name}")
+            if check_fn(obj, *check_fn_args):
+                matches.append(f"{module_name}.{name}")
 
     return matches
 
@@ -374,7 +365,9 @@ def write_rst(
 if __name__ == "__main__":
     model_classes: list[str] = sorted(
         ["mfai.pytorch.models.base.ModelABC"]
-        + get_classes_matching("mfai.pytorch.models", attribute="model_type")
+        + get_classes_matching(
+            "mfai.pytorch.models", check_fn=hasattr, check_fn_args=["model_type"]
+        )
     )
     write_rst(
         title="Models",
@@ -391,7 +384,8 @@ if __name__ == "__main__":
                 "classes": sorted(
                     get_classes_matching(
                         "mfai.pytorch.losses",
-                        ["Module"],
+                        check_fn=is_subclass_of_names,
+                        check_fn_args=[["Module"]],
                     )
                 ),
             }
@@ -406,14 +400,16 @@ if __name__ == "__main__":
                 "title": "Lightning Modules",
                 "classes": get_classes_matching(
                     "mfai.pytorch.lightning_modules",
-                    ["LightningModule"],
+                    check_fn=is_subclass_of_names,
+                    check_fn_args=[["LightningModule"]],
                 ),
             },
             {
                 "title": "Callbacks",
                 "classes": get_classes_matching(
                     "mfai.pytorch",
-                    ["Callback"],
+                    check_fn=is_subclass_of_names,
+                    check_fn_args=[["Callback"]],
                 ),
             },
         ],
@@ -427,7 +423,8 @@ if __name__ == "__main__":
                 "title": "Transforms",
                 "classes": get_classes_matching(
                     "mfai.pytorch.transforms",
-                    ["object"],
+                    check_fn=is_subclass_of_names,
+                    check_fn_args=[["object"]],
                 ),
             }
         ],
@@ -441,7 +438,8 @@ if __name__ == "__main__":
                 "title": "Metrics",
                 "classes": get_classes_matching(
                     "mfai.pytorch.metrics",
-                    ["Metric"],
+                    check_fn=is_subclass_of_names,
+                    check_fn_args=[["Metric"]],
                 ),
             }
         ],

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,6 @@
 
 Packages documentation
-===================
+======================
 
 `mfai` is a Python package that provides the following features:
 
@@ -10,7 +10,7 @@ Packages documentation
 - Various losses from the litterature, often tailored to our projects and experimental results
 - Lightning module to speedup recurring tasks: segmentation, regression, DGMR training, ...
 
-===================
+======================
 
 .. toctree::
    :maxdepth: 1
@@ -37,7 +37,7 @@ Packages documentation
    contributing
 
 Indices and tables
-===================
+==================
 
 * :ref:`genindex`
 * :ref:`modindex`

--- a/mfai/pytorch/models/base.py
+++ b/mfai/pytorch/models/base.py
@@ -26,6 +26,7 @@ class ModelType(Enum):
     MULTIMODAL_LLM = 5
     PANGU = 6
     IDENTITY = 7
+    DGMR = 8
 
 
 class ModelABC(ABC):

--- a/mfai/pytorch/models/dgmr/blocks.py
+++ b/mfai/pytorch/models/dgmr/blocks.py
@@ -11,7 +11,7 @@ from torch.nn.modules.pixelshuffle import PixelUnshuffle
 from torch.nn.utils.parametrizations import spectral_norm
 
 from .layers import AttentionLayer, get_conv_layer
-
+from ..base import ModelType
 
 class GBlock(torch.nn.Module):
     """Residual generator block without upsampling."""
@@ -330,6 +330,8 @@ class LBlock(torch.nn.Module):
 class ContextConditioningStack(torch.nn.Module):
     """Context conditioning stack."""
 
+    model_type: ModelType = ModelType.DGMR
+
     def __init__(
         self,
         input_channels: int = 1,
@@ -463,6 +465,8 @@ class ContextConditioningStack(torch.nn.Module):
 
 class LatentConditioningStack(torch.nn.Module):
     """Latent conditioning stack class."""
+
+    model_type: ModelType = ModelType.DGMR
 
     def __init__(
         self,

--- a/mfai/pytorch/models/dgmr/blocks.py
+++ b/mfai/pytorch/models/dgmr/blocks.py
@@ -13,6 +13,7 @@ from torch.nn.utils.parametrizations import spectral_norm
 from .layers import AttentionLayer, get_conv_layer
 from ..base import ModelType
 
+
 class GBlock(torch.nn.Module):
     """Residual generator block without upsampling."""
 

--- a/mfai/pytorch/models/dgmr/blocks.py
+++ b/mfai/pytorch/models/dgmr/blocks.py
@@ -10,8 +10,8 @@ from torch.distributions import normal
 from torch.nn.modules.pixelshuffle import PixelUnshuffle
 from torch.nn.utils.parametrizations import spectral_norm
 
-from .layers import AttentionLayer, get_conv_layer
 from ..base import ModelType
+from .layers import AttentionLayer, get_conv_layer
 
 
 class GBlock(torch.nn.Module):

--- a/mfai/pytorch/models/dgmr/discriminators.py
+++ b/mfai/pytorch/models/dgmr/discriminators.py
@@ -10,8 +10,8 @@ from torch.nn.modules.pixelshuffle import PixelUnshuffle
 from torch.nn.utils.parametrizations import spectral_norm
 from torchvision.transforms import RandomCrop
 
-from .blocks import DBlock
 from ..base import ModelType
+from .blocks import DBlock
 
 
 class Discriminator(torch.nn.Module):

--- a/mfai/pytorch/models/dgmr/discriminators.py
+++ b/mfai/pytorch/models/dgmr/discriminators.py
@@ -11,10 +11,13 @@ from torch.nn.utils.parametrizations import spectral_norm
 from torchvision.transforms import RandomCrop
 
 from .blocks import DBlock
+from ..base import ModelType
 
 
 class Discriminator(torch.nn.Module):
     """Discriminators class."""
+
+    model_type: ModelType = ModelType.DGMR
 
     def __init__(
         self,
@@ -63,6 +66,8 @@ class Discriminator(torch.nn.Module):
 
 class TemporalDiscriminator(torch.nn.Module):
     """Temporal Discriminator class."""
+
+    model_type: ModelType = ModelType.DGMR
 
     def __init__(
         self,
@@ -167,6 +172,8 @@ class TemporalDiscriminator(torch.nn.Module):
 
 class SpatialDiscriminator(torch.nn.Module):
     """Spatial Discriminator class."""
+
+    model_type: ModelType = ModelType.DGMR
 
     def __init__(
         self,

--- a/mfai/pytorch/models/dgmr/generators.py
+++ b/mfai/pytorch/models/dgmr/generators.py
@@ -8,6 +8,7 @@ from torch import Tensor
 from torch.nn.modules.pixelshuffle import PixelShuffle
 from torch.nn.utils.parametrizations import spectral_norm
 
+from ..base import ModelType
 from .blocks import (
     ContextConditioningStack,
     GBlock,
@@ -15,7 +16,6 @@ from .blocks import (
     UpsampleGBlock,
 )
 from .layers import ConvGRU
-from ..base import ModelType
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARN)

--- a/mfai/pytorch/models/dgmr/generators.py
+++ b/mfai/pytorch/models/dgmr/generators.py
@@ -15,6 +15,7 @@ from .blocks import (
     UpsampleGBlock,
 )
 from .layers import ConvGRU
+from ..base import ModelType
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARN)
@@ -22,6 +23,8 @@ logger.setLevel(logging.WARN)
 
 class Sampler(torch.nn.Module):
     """Sampler class."""
+
+    model_type: ModelType = ModelType.DGMR
 
     def __init__(
         self,
@@ -207,6 +210,8 @@ class Sampler(torch.nn.Module):
 
 class Generator(torch.nn.Module):
     """Generator class."""
+
+    model_type: ModelType = ModelType.DGMR
 
     def __init__(
         self,


### PR DESCRIPTION
A model is now added to the "models/" section of the documentation if a class has the attribute `model_type`. All these classes are then sorted by `model_type` as below:

<img width="1594" height="875" alt="image" src="https://github.com/user-attachments/assets/51053a4c-f96f-4d8d-bdc8-73318f32ea64" />
