### PR TITLE
📌 set tokenizers to >=0.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ llm = [
   "sentencepiece>=0.2",
   "tensorflow>=2.20",
   "tiktoken>=0.8",
-  "tokenizers>=0.23.1",
+  "tokenizers>=0.22",
 ]
 docs = [
   "sphinx>=7.0.0",

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -40,7 +40,7 @@ from mfai.tokenizers import GPT2Tokenizer, LlamaTokenizer, Qwen3_5Tokenizer, Tok
         ),
         (
             partial(Qwen3_5, Qwen3_5Settings()),
-            "Hello, I am键千千万 хоче ని металлуasted项 сомненияPosX Romeo",
+            "Hello, I am键千千万 хоче ని металлуasted项手感预告ত্ত",
             Qwen3_5Tokenizer(apply_chat_template=False),
         ),
     ],

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -40,7 +40,7 @@ from mfai.tokenizers import GPT2Tokenizer, LlamaTokenizer, Qwen3_5Tokenizer, Tok
         ),
         (
             partial(Qwen3_5, Qwen3_5Settings()),
-            "Hello, I am键千千万 хоче ని металлуasted项手感预告ত্ত",
+            "Hello, I am键千千万 хоче ని металлуasted项 сомненияPosX Romeo",
             Qwen3_5Tokenizer(apply_chat_template=False),
         ),
     ],


### PR DESCRIPTION
to allow mfai compatibility with the `transformers` lib.