### PR TITLE
Remove import qwen3 5tokenizer in qwen3 5

### DIFF
--- a/mfai/pytorch/models/llms/qwen3_5.py
+++ b/mfai/pytorch/models/llms/qwen3_5.py
@@ -24,7 +24,6 @@ from safetensors.torch import load_file
 from torch import Tensor
 
 from mfai.pytorch.models.base import ModelType
-from mfai.tokenizers import Qwen3_5Tokenizer
 
 use_fast_conv1d = False
 try:
@@ -1156,10 +1155,10 @@ class Qwen3_5(nn.Module):
                 # Feed only the new token to the model; cache handles history
                 logits = self(next_token, cache=cache)
 
-    def generate_text(
+    def generate_text(  # type: ignore[no-untyped-def]
         self,
         prompt: str,
-        tokenizer: Qwen3_5Tokenizer,
+        tokenizer,
         max_new_tokens: int,
     ) -> str:
         input_token_ids = tokenizer.encode(prompt)
@@ -1181,8 +1180,9 @@ class Qwen3_5(nn.Module):
 
 if __name__ == "__main__":
     # Exemple of basic usage
-
     import time
+
+    from mfai.tokenizers import Qwen3_5Tokenizer
 
     # Create model Qwen 3.5
     torch.manual_seed(123)

--- a/runai_settings.sh
+++ b/runai_settings.sh
@@ -1,1 +1,1 @@
-RUNAI_DOCKER_FILENAME=Dockerfile.mf
+export RUNAI_DOCKER_FILENAME=Dockerfile.mf


### PR DESCRIPTION
Remove import in head of file `mfai.pytorch.models.llm.qwen3_5` to avoid contamination of `[llm]` dependencies with other models or lightning module.

Add `export` in `runai_settings.sh` to properly export variable (necessary for the python version of runai) .