### PR TITLE
More optional dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       if: github.event_name != 'pull_request' || steps.changed-py-files.outputs.any_changed == 'true' 
       run: |
         pip install --upgrade pip
-        pip install .[all]
+        pip install .[llm,weather_forecast,vision_transformers,dev]
         pip install mlflow
 
     - name: Type hinting with mypy on changed files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       if: github.event_name != 'pull_request' || steps.changed-py-files.outputs.any_changed == 'true' 
       run: |
         pip install --upgrade pip
-        pip install .[llm,dev]
+        pip install .[all]
         pip install mlflow
 
     - name: Type hinting with mypy on changed files

--- a/README.md
+++ b/README.md
@@ -415,9 +415,6 @@ We provide a [RandomCropWithMinPositivePixels](https://github.com/meteofrance/mf
 
 # Installation
 
-
-
-
 ## Cloning the repository
 
 ```bash
@@ -447,22 +444,20 @@ Before version 6.2.1:
 pip install git+https://github.com/meteofrance/mfai@v1.0.1
 ```
 
-After version 7.0.0, mfai comes with optional dependencies for llm models.
-To install them, add `[llm]` behind the pip installation instruction:
+To lighten dependencies, mfai comes with optional dependencies for specific models:
+- `llm` for llm models (Tokenizers, GPT2, Llama2, Llama3, Fuyu, Qwen)
+- `vision_transformers` for for vision transformer models (Swinunetr, UnetrPP)
+- `weather_forecast` for weather forcasting models (Nlam, pangu, archesweather)
+- `dev` for development dependencies (unit tests, type checking)
+- `doc` for documentation build dependencies
+
+Install only what your project requires with:
 ```bash
-pip install .[dev]
-
-
-# or
-
-pip install mfai[llm]>=7.0.0
+pip install mfai[llm, vision_transformers]>=8.0.0
 ```
 
 
 # Usage
-
-
-
 
 ## Instanciate a model
 

--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -39,7 +39,7 @@ class MLFlowSystemMonitorCallback(L.Callback):
                 "MLFlowSystemMonitorCallback requires MLFlowLogger"
             )
 
-        from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
+        from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor  #type: ignore[import-not-found]
 
         self.system_monitor = SystemMetricsMonitor(
             run_id=trainer.logger.run_id,

--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -40,7 +40,7 @@ class MLFlowSystemMonitorCallback(L.Callback):
             )
 
         from mlflow.system_metrics.system_metrics_monitor import (
-            SystemMetricsMonitor,  # type: ignore[import-not-found]
+            SystemMetricsMonitor,
         )
 
         self.system_monitor = SystemMetricsMonitor(

--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -39,9 +39,7 @@ class MLFlowSystemMonitorCallback(L.Callback):
                 "MLFlowSystemMonitorCallback requires MLFlowLogger"
             )
 
-        from mlflow.system_metrics.system_metrics_monitor import (
-            SystemMetricsMonitor,
-        )
+        from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
 
         self.system_monitor = SystemMetricsMonitor(
             run_id=trainer.logger.run_id,

--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -39,7 +39,9 @@ class MLFlowSystemMonitorCallback(L.Callback):
                 "MLFlowSystemMonitorCallback requires MLFlowLogger"
             )
 
-        from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor  #type: ignore[import-not-found]
+        from mlflow.system_metrics.system_metrics_monitor import (
+            SystemMetricsMonitor,  # type: ignore[import-not-found]
+        )
 
         self.system_monitor = SystemMetricsMonitor(
             run_id=trainer.logger.run_id,

--- a/mfai/pytorch/models/archesweather.py
+++ b/mfai/pytorch/models/archesweather.py
@@ -7,13 +7,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as gradient_checkpoint
-from axial_attention import (  # type: ignore[import-untyped]
-    AxialAttention,
-    AxialPositionalEmbedding,
-)
 from dataclasses_json import dataclass_json
 from einops import rearrange
-from timm.layers import DropPath
 from torch import Tensor
 from torch.nn import LayerNorm
 from torch.utils.checkpoint import checkpoint
@@ -30,6 +25,20 @@ from .pangu import (
     UpSample,
     generate_3d_attention_mask,
 )
+
+# Optional dependency
+try:
+    from axial_attention import (  # type: ignore[import-untyped]
+        AxialAttention,
+        AxialPositionalEmbedding,
+    )
+    from timm.layers import DropPath
+except ImportError as e:
+    print(
+        "To use the ArchesWeather model, install mfai's "
+        "optional dependency\n\tmfai[weather_forecast]"
+    )
+    raise e
 
 
 class EarthSpecificBlock(nn.Module):

--- a/mfai/pytorch/models/llms/__init__.py
+++ b/mfai/pytorch/models/llms/__init__.py
@@ -1,8 +1,24 @@
+from importlib.util import find_spec
+
 from torch import nn
 
 from mfai.pytorch.models.llms.gpt2 import GPT2, CrossAttentionGPT2
 from mfai.pytorch.models.llms.llama2 import Llama2
 from mfai.pytorch.models.llms.llama3 import Llama3
+
+# Check for optional dependency
+if any(
+    (
+        find_spec("huggingface_hub") is None,
+        find_spec("sentencepiece") is None,
+        find_spec("tensorflow") is None,
+        find_spec("tiktoken") is None,
+        find_spec("tokenizers") is None,
+    )
+):
+    raise ImportError(
+        "To use mfai's llm models, install mfai's optional dependency\n\tmfai[llm]"
+    )
 
 
 class FreezeMLMMixin:

--- a/mfai/pytorch/models/llms/__init__.py
+++ b/mfai/pytorch/models/llms/__init__.py
@@ -2,10 +2,6 @@ from importlib.util import find_spec
 
 from torch import nn
 
-from mfai.pytorch.models.llms.gpt2 import GPT2, CrossAttentionGPT2
-from mfai.pytorch.models.llms.llama2 import Llama2
-from mfai.pytorch.models.llms.llama3 import Llama3
-
 # Check for optional dependency
 if any(
     (
@@ -19,6 +15,10 @@ if any(
     raise ImportError(
         "To use mfai's llm models, install mfai's optional dependency\n\tmfai[llm]"
     )
+
+from mfai.pytorch.models.llms.gpt2 import GPT2, CrossAttentionGPT2
+from mfai.pytorch.models.llms.llama2 import Llama2
+from mfai.pytorch.models.llms.llama3 import Llama3
 
 
 class FreezeMLMMixin:

--- a/mfai/pytorch/models/nlam/__init__.py
+++ b/mfai/pytorch/models/nlam/__init__.py
@@ -3,11 +3,11 @@ Graph Neural Network architectures adapted from https://github.com/mllam/neural-
 """
 
 from dataclasses import dataclass
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Any, Literal
 
 import torch
-import torch_geometric as pyg
 from dataclasses_json import dataclass_json
 from torch import Tensor, nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import offload_wrapper
@@ -17,6 +17,19 @@ from mfai.pytorch.models.utils import expand_to_batch
 
 from .create_mesh import build_graph_for_grid
 from .interaction_net import InteractionNet, make_mlp
+
+# Check for optional dependency
+if any(
+    (
+        find_spec("torch_geometric") is None,
+        find_spec("scipy") is None,
+    )
+):
+    raise ImportError(
+        "To use the GraphLAM, HiLAM or HiLAMParallel models, "
+        "install mfai's optional dependency\n\tmfai[weather_forecast]"
+    )
+import torch_geometric as pyg
 
 
 def offload_to_cpu(model: nn.ModuleList) -> nn.ModuleList:

--- a/mfai/pytorch/models/pangu.py
+++ b/mfai/pytorch/models/pangu.py
@@ -5,7 +5,6 @@ from typing import Optional, Tuple
 
 import torch
 from dataclasses_json import dataclass_json
-from timm.layers import DropPath
 from torch import Tensor, nn
 from torch.nn import (
     GELU,
@@ -23,6 +22,16 @@ from torch.nn import (
 from torch.utils.checkpoint import checkpoint
 
 from .base import BaseModel, ModelType
+
+# Optional dependency
+try:
+    from timm.layers import DropPath
+except ImportError as e:
+    print(
+        "To use the PanguWeather model, install mfai's "
+        "optional dependency\n\tmfai[weather_forecast]"
+    )
+    raise e
 
 
 def define_3d_earth_position_index(window_size: Tuple[int, int, int]) -> Tensor:

--- a/mfai/pytorch/models/swinunetr.py
+++ b/mfai/pytorch/models/swinunetr.py
@@ -4,11 +4,20 @@ from typing import Any, Literal
 
 import torch
 from dataclasses_json import dataclass_json
-from monai.networks.blocks.dynunet_block import UnetResBlock
-from monai.networks.nets.swin_unetr import SwinUNETR as MonaiSwinUNETR
 from torch import Tensor, nn
 
 from .base import AutoPaddingModel, ModelABC, ModelType
+
+# Optional dependency
+try:
+    from monai.networks.blocks.dynunet_block import UnetResBlock
+    from monai.networks.nets.swin_unetr import SwinUNETR as MonaiSwinUNETR
+except ImportError as e:
+    print(
+        "To use the SwinUnet model, install mfai's "
+        "optional dependency\n\tmfai[vision_transformers]"
+    )
+    raise e
 
 
 @dataclass_json

--- a/mfai/pytorch/models/unetrpp.py
+++ b/mfai/pytorch/models/unetrpp.py
@@ -12,20 +12,29 @@ from typing import Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from dataclasses_json import dataclass_json
-from monai.networks.blocks.dynunet_block import (
-    UnetOutBlock,
-    UnetResBlock,
-    get_conv_layer,
-    get_output_padding,
-    get_padding,
-)
-from monai.networks.layers.utils import get_norm_layer
-from monai.utils import optional_import
 from torch import Tensor
 from torch.nn.functional import scaled_dot_product_attention
 
 from .base import AutoPaddingModel, BaseModel, ModelType
+
+# Optional dependency
+try:
+    from dataclasses_json import dataclass_json
+    from monai.networks.blocks.dynunet_block import (
+        UnetOutBlock,
+        UnetResBlock,
+        get_conv_layer,
+        get_output_padding,
+        get_padding,
+    )
+    from monai.networks.layers.utils import get_norm_layer
+    from monai.utils import optional_import
+except ImportError as e:
+    print(
+        "To use the UNetRPP model, install mfai's "
+        "optional dependency\n\tmfai[vision_transformers]"
+    )
+    raise e
 
 
 def _trunc_normal_(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,30 +42,37 @@ dynamic = ["version"]
 license-files = ["LICENSE"]
 keywords = ["PyTorch", "Deep Learning", "Artificial Intelligence", "Meteo-France"]
 dependencies = [
-  "axial-attention>=0.6.1",
   "dataclasses-json>=0.6",
   "einops>=0.8",
   "lightning[pytorch-extra]",
-  "monai>=1.5",
   "onnx>=1.17.0",
   "onnxruntime>=1.20",
   "onnxscript>=0.1",
-  "scipy>=1.14",
   "torch>=2.5,<3",
   "torchvision>=0.19",
   "tabulate>=0.9",
-  "timm>=1.0",
   "torchmetrics>=1.6",
-  "torch-geometric>=2.6",
 ]
 
 [project.optional-dependencies]
 llm = [
+  # Tokenizers, GPT2, Llama2, Llama3, Fuyu, Qwen
   "huggingface_hub>=0.26",
   "sentencepiece>=0.2",
   "tensorflow>=2.20",
   "tiktoken>=0.8",
   "tokenizers>=0.22",
+]
+weather_forecast = [
+  # Nlam, pangu and archesweather models
+  "timm>=1.0",
+  "scipy>=1.14",
+  "torch-geometric>=2.6",
+  "axial-attention>=0.6.1",
+]
+vision_transformers = [
+  # Swinunetr and UnetrPP models
+  "monai>=1.5",
 ]
 docs = [
   "sphinx>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,12 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/meteofrance/mfai"
 
+[tool.uv]
+# Enforces the use of prebuilt binary wheels over source distributions
+# that require a build step and executes arbitrary code when installing.
+pip.only-binary = [":all:"]
+exclude-newer = "15 days"
+
 [tool.ruff]
 target-version = "py312"
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools==83.0.0", "wheel==0.47.0", "setuptools-git-versioning==3.1.0"]
+requires = [
+  "setuptools==83.0.0",
+  "wheel==0.47.0",
+  "setuptools-git-versioning==3.1.0",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.package-dir]
@@ -10,37 +14,42 @@ enabled = true
 
 [tool.setuptools.package-data]
 mfai = [
-# Include tiktoken cache files
+  # Include tiktoken cache files
   "tokenizers/tiktoken_cache/6c7ea1a7e38e3a7f062df639a5b80947f075ffe6",
   "tokenizers/tiktoken_cache/6d1cbeee0f20b3d9449abfede4726ed8212e3aee",
 
-# Include marker file `py.typed` to respect PEP561 and declare this package as type hinted
+  # Include marker file `py.typed` to respect PEP561 and declare this package as type hinted
   "py.typed",
 
-# include Qwen3.5 tokenizer file
+  # include Qwen3.5 tokenizer file
   "tokenizers/qwen3.5/tokenizer.json",
 ]
 
 [project]
 name = "mfai"
 authors = [
-  {name="Frank Guibert", email="frank.guibert@meteo.fr"},
-  {name="Theo Tournier", email="theo.tournier@meteo.fr"},
-  {name="Lea Berthomier", email="lea.berthomier@meteo.fr"},
-  {name="Bruno Pradel", email="bruno.pradel@meteo.fr"},
-  {name="Oscar Dewasmes", email="oscar.dewasmes@meteo.fr"},
+  { name = "Frank Guibert", email = "frank.guibert@meteo.fr" },
+  { name = "Theo Tournier", email = "theo.tournier@meteo.fr" },
+  { name = "Lea Berthomier", email = "lea.berthomier@meteo.fr" },
+  { name = "Bruno Pradel", email = "bruno.pradel@meteo.fr" },
+  { name = "Oscar Dewasmes", email = "oscar.dewasmes@meteo.fr" },
 ]
 description = "Meteo-France's Artificial Intelligence Python Package"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: Apache Software License",
-    "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
 ]
 dynamic = ["version"]
 license-files = ["LICENSE"]
-keywords = ["PyTorch", "Deep Learning", "Artificial Intelligence", "Meteo-France"]
+keywords = [
+  "PyTorch",
+  "Deep Learning",
+  "Artificial Intelligence",
+  "Meteo-France",
+]
 dependencies = [
   "dataclasses-json>=0.6",
   "einops>=0.8",
@@ -105,12 +114,7 @@ exclude-newer = "15 days"
 target-version = "py312"
 line-length = 88
 builtins = ["_"]
-include = [
-  "mfai/**/*.py",
-  "exemples/**/*.py",
-  "tests/**/*.py",
-  "doc/**/*.py",
-]
+include = ["mfai/**/*.py", "exemples/**/*.py", "tests/**/*.py", "doc/**/*.py"]
 exclude = []
 
 [tool.ruff.format]
@@ -118,29 +122,29 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 select = [
-  "I",  # I = isort
-  "F",  # pyflakes
-  "W",  # pycodestyle warnings
-  "E",  # pycodestyle errors
-  "D",  # pydocstyle
+  "I", # I = isort
+  "F", # pyflakes
+  "W", # pycodestyle warnings
+  "E", # pycodestyle errors
+  "D", # pydocstyle
 ]
 ignore = [
-    "D100",  # Allow undocumented-public-module
-    "D200",  # Allow unnecessayry-multiline-docstring
-    "D202",  # Allow blank-line-after-function after function docstring
-    "D203",  # Allow incorrect-blank-line-before-class
-    "D205",  # Allow missing-blank-line-after-summary
-    "D212",  # Allow multi-line-summary-first-line
-    "D213",  # Allow multi-line-summary-second-line
-    "D415",  # Allow missing-terminal-punctuation
+  "D100", # Allow undocumented-public-module
+  "D200", # Allow unnecessayry-multiline-docstring
+  "D202", # Allow blank-line-after-function after function docstring
+  "D203", # Allow incorrect-blank-line-before-class
+  "D205", # Allow missing-blank-line-after-summary
+  "D212", # Allow multi-line-summary-first-line
+  "D213", # Allow multi-line-summary-second-line
+  "D415", # Allow missing-terminal-punctuation
 
-    "D101",  # Allow undocumented-public-class
-    "D102",  # Allow undocumented-public-method
-    "D103",  # Allow undocumented-public-function
-    "D104",  # Allow undocumented-public-package
-    "D105",  # Allow undocumented-magic-method
-    "D107",  # Allow undocumented-public-init
-    "E501",  # Allow line too long
+  "D101", # Allow undocumented-public-class
+  "D102", # Allow undocumented-public-method
+  "D103", # Allow undocumented-public-function
+  "D104", # Allow undocumented-public-package
+  "D105", # Allow undocumented-magic-method
+  "D107", # Allow undocumented-public-init
+  "E501", # Allow line too long
 ]
 
 [tool.ruff.lint.pydocstyle]
@@ -162,15 +166,11 @@ fail_under = 85
 
 [tool.coverage.report]
 show_missing = true
-exclude_also = [
-    'def __repr__',
-    'if __name__ == .__main__.:',
-]
+exclude_also = ['def __repr__', 'if __name__ == .__main__.:']
 
 [tool.mypy]
 # [mypy configuration file doc](https://mypy.readthedocs.io/en/stable/config_file.html#confval-exclude)
-exclude = [
-]
+exclude = []
 
 # Disallows defining functions without type annotations or with incomplete type annotations.
 # Use Any for *args and **kwargs
@@ -184,9 +184,7 @@ implicit_optional = true
 # This clarifies the intent of the ignore and ensures that only the expected errors are silenced.
 # Ignore comments should contain the error code silenced:
 # a: str = 1  # type: ignore[assignment]
-enable_error_code = [
-  "ignore-without-code"
-]
+enable_error_code = ["ignore-without-code"]
 
 # Warn when a `#type: ignore` silences a line that is not actually generating an error
 warn_unused_ignores = true
@@ -196,9 +194,7 @@ warn_unreachable = true
 
 # Disable the check for dynamically defined attributes, for more details see link below
 # [attr-defined](https://mypy.readthedocs.io/en/stable/error_code_list.html#check-that-attribute-exists-attr-defined)
-disable_error_code = [
-  "attr-defined", "unreachable"
-]
+disable_error_code = ["attr-defined", "unreachable"]
 
 # Configure mypy output styling
 show_error_code_links = true
@@ -219,5 +215,6 @@ module = [
   "scipy.spatial",
   "timm.*",
   "flash_attn.*",
+  "mlflow.*",
 ]
 ignore_missing_imports = true

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 import torch
+from torch import nn
 from test_multimodal_lm import generate_text_simple
 
 from mfai.pytorch.models.llms.gpt2 import (
@@ -71,7 +72,7 @@ def test_llms(model_target_tokenizer: tuple[Any, str, Tokenizer]) -> None:
         (Llama3(Llama3Settings()), LlamaTokenizer()),
     ],
 )
-def test_kv_cache(model_tokenizer: tuple[GPT2, GPT2Settings]) -> None:
+def test_kv_cache(model_tokenizer: tuple[nn.Module, Tokenizer]) -> None:
     """
     We check that KV cache implementation is working and a speed-up text generation.
     """

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import pytest
 import torch
-from torch import nn
 from test_multimodal_lm import generate_text_simple
+from torch import nn
 
 from mfai.pytorch.models.llms.gpt2 import (
     GPT2,
@@ -86,7 +86,7 @@ def test_kv_cache(model_tokenizer: tuple[nn.Module, Tokenizer]) -> None:
         model=model,
         idx=encoded_tensor,
         max_new_tokens=400,
-        context_size=model.context_length,
+        context_size=model.context_length,  #type: ignore[arg-type]
         use_cache=False,
     )
     end = time.perf_counter()
@@ -98,7 +98,7 @@ def test_kv_cache(model_tokenizer: tuple[nn.Module, Tokenizer]) -> None:
         model=model,
         idx=encoded_tensor,
         max_new_tokens=400,
-        context_size=model.context_length,
+        context_size=model.context_length,  #type: ignore[arg-type]
         use_cache=True,
     )
     end = time.perf_counter()

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -86,7 +86,7 @@ def test_kv_cache(model_tokenizer: tuple[nn.Module, Tokenizer]) -> None:
         model=model,
         idx=encoded_tensor,
         max_new_tokens=400,
-        context_size=model.context_length,  #type: ignore[arg-type]
+        context_size=model.context_length,  # type: ignore[arg-type]
         use_cache=False,
     )
     end = time.perf_counter()
@@ -98,7 +98,7 @@ def test_kv_cache(model_tokenizer: tuple[nn.Module, Tokenizer]) -> None:
         model=model,
         idx=encoded_tensor,
         max_new_tokens=400,
-        context_size=model.context_length,  #type: ignore[arg-type]
+        context_size=model.context_length,  # type: ignore[arg-type]
         use_cache=True,
     )
     end = time.perf_counter()

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P15D"
+
 [[package]]
 name = "absl-py"
 version = "2.5.0"
@@ -1715,22 +1719,15 @@ wheels = [
 name = "mfai"
 source = { editable = "." }
 dependencies = [
-    { name = "axial-attention" },
     { name = "dataclasses-json" },
     { name = "einops" },
     { name = "lightning", extra = ["pytorch-extra"] },
-    { name = "monai" },
     { name = "onnx" },
     { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "onnxscript" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "tabulate" },
-    { name = "timm" },
     { name = "torch" },
-    { name = "torch-geometric" },
     { name = "torchmetrics" },
     { name = "torchvision" },
 ]
@@ -1765,17 +1762,28 @@ llm = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
+vision-transformers = [
+    { name = "monai" },
+]
+weather-forecast = [
+    { name = "axial-attention" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "timm" },
+    { name = "torch-geometric" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "axial-attention", specifier = ">=0.6.1" },
+    { name = "axial-attention", marker = "extra == 'weather-forecast'", specifier = ">=0.6.1" },
     { name = "dataclasses-json", specifier = ">=0.6" },
     { name = "einops", specifier = ">=0.8" },
     { name = "furo", marker = "extra == 'docs'" },
     { name = "ghp-import", marker = "extra == 'docs'" },
     { name = "huggingface-hub", marker = "extra == 'llm'", specifier = ">=0.26" },
     { name = "lightning", extras = ["pytorch-extra"] },
-    { name = "monai", specifier = ">=1.5" },
+    { name = "monai", marker = "extra == 'vision-transformers'", specifier = ">=1.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "myst-parser", marker = "extra == 'docs'" },
     { name = "onnx", specifier = ">=1.17.0" },
@@ -1784,7 +1792,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
-    { name = "scipy", specifier = ">=1.14" },
+    { name = "scipy", marker = "extra == 'weather-forecast'", specifier = ">=1.14" },
     { name = "sentencepiece", marker = "extra == 'llm'", specifier = ">=0.2" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.0" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'" },
@@ -1792,17 +1800,17 @@ requires-dist = [
     { name = "tabulate", specifier = ">=0.9" },
     { name = "tensorflow", marker = "extra == 'llm'", specifier = ">=2.20" },
     { name = "tiktoken", marker = "extra == 'llm'", specifier = ">=0.8" },
-    { name = "timm", specifier = ">=1.0" },
+    { name = "timm", marker = "extra == 'weather-forecast'", specifier = ">=1.0" },
     { name = "tokenizers", marker = "extra == 'llm'", specifier = ">=0.22" },
     { name = "torch", specifier = ">=2.5,<3" },
-    { name = "torch-geometric", specifier = ">=2.6" },
+    { name = "torch-geometric", marker = "extra == 'weather-forecast'", specifier = ">=2.6" },
     { name = "torchmetrics", specifier = ">=1.6" },
     { name = "torchvision", specifier = ">=0.19" },
     { name = "types-tabulate", marker = "extra == 'dev'", specifier = "==0.10.0.20260508" },
     { name = "types-tensorflow", marker = "extra == 'dev'", specifier = "==2.18.0.20260610" },
     { name = "types-tqdm", marker = "extra == 'dev'", specifier = "==4.68.0.20260608" },
 ]
-provides-extras = ["llm", "docs", "dev"]
+provides-extras = ["llm", "weather-forecast", "vision-transformers", "docs", "dev"]
 
 [[package]]
 name = "ml-dtypes"


### PR DESCRIPTION
Move to optional dependencies dependencies specific to a few models. Add error catching on optional dependencies imports to give an explicit message to mfai's users.

Last PR before tagging v8.0.0