### PR TITLE
MLFlowSaveConfigCallback works with `_artifact_location` and `save_dir`

### DIFF
--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -76,7 +76,6 @@ class MLFlowSaveConfigCallback(SaveConfigCallback):
             if trainer.logger._artifact_location:
                 dir_run = (
                     Path(trainer.logger._artifact_location)
-                    / trainer.logger.experiment_id
                     / trainer.logger.run_id
                     / "artifacts"
                 )

--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -81,7 +81,9 @@ class MLFlowSaveConfigCallback(SaveConfigCallback):
                     / trainer.logger.run_id
                 )
             else:
-                raise TypeError("Please ensure that the logger is a `MLFlowLogger` with `artifact_location` or `save_dir` set.")
+                raise TypeError(
+                    "Please ensure that the logger is a `MLFlowLogger` with `artifact_location` or `save_dir` set."
+                )
 
             path_config = dir_run / self.config_filename
             dir_run.mkdir(exist_ok=True, parents=True)

--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -66,23 +66,29 @@ class MLFlowSaveConfigCallback(SaveConfigCallback):
     def save_config(
         self, trainer: L.Trainer, pl_module: L.LightningModule, stage: str
     ) -> None:
-        if hasattr(trainer, "logger"):
-            if hasattr(trainer.logger, "_artifact_location"):
+        if isinstance(trainer.logger, MLFlowLogger):
+            assert trainer.logger.experiment_id, (
+                "'experiment_id' is not defined in the MLFlowLogger."
+            )
+            assert trainer.logger.run_id, "'run_id' is not defined in the MLFlowLogger."
+
+            dir_run: Path
+            if trainer.logger._artifact_location:
                 dir_run = (
                     Path(trainer.logger._artifact_location)
                     / trainer.logger.experiment_id
                     / trainer.logger.run_id
                     / "artifacts"
                 )
-            elif hasattr(trainer.logger, "save_dir"):
+            elif trainer.logger.save_dir:
                 dir_run = (
                     Path(trainer.logger.save_dir)
                     / trainer.logger.experiment_id
                     / trainer.logger.run_id
                 )
             else:
-                raise TypeError(
-                    "Please ensure that the logger is a `MLFlowLogger` with `artifact_location` or `save_dir` set."
+                raise AttributeError(
+                    "Please ensure that 'artifact_location' or 'save_dir' attribute is set in the MLFlowLogger."
                 )
 
             path_config = dir_run / self.config_filename
@@ -94,4 +100,8 @@ class MLFlowSaveConfigCallback(SaveConfigCallback):
                 skip_none=False,
                 overwrite=self.overwrite,
                 multifile=self.multifile,
+            )
+        else:
+            raise TypeError(
+                f"Please ensure that the logger is a 'MLFlowLogger', got '{type(trainer)}'."
             )

--- a/mfai/pytorch/callbacks.py
+++ b/mfai/pytorch/callbacks.py
@@ -53,7 +53,8 @@ class MLFlowSystemMonitorCallback(L.Callback):
 
 class MLFlowSaveConfigCallback(SaveConfigCallback):
     """A Lightning callback to save the `config.yaml` in the run directory
-    instead of in the top-level `save_dir`.
+    instead of in the top-level `save_dir` or `artifact_location`.
+
     See the issue: https://github.com/Lightning-AI/pytorch-lightning/issues/20184
     """
 
@@ -65,12 +66,25 @@ class MLFlowSaveConfigCallback(SaveConfigCallback):
     def save_config(
         self, trainer: L.Trainer, pl_module: L.LightningModule, stage: str
     ) -> None:
-        if trainer.logger and trainer.logger.save_dir:
-            dir_runs = Path(trainer.logger.save_dir)
-            dir_run = dir_runs / trainer.logger.experiment_id / trainer.logger.run_id
-            path_config = dir_run / self.config_filename
+        if hasattr(trainer, "logger"):
+            if hasattr(trainer.logger, "_artifact_location"):
+                dir_run = (
+                    Path(trainer.logger._artifact_location)
+                    / trainer.logger.experiment_id
+                    / trainer.logger.run_id
+                    / "artifacts"
+                )
+            elif hasattr(trainer.logger, "save_dir"):
+                dir_run = (
+                    Path(trainer.logger.save_dir)
+                    / trainer.logger.experiment_id
+                    / trainer.logger.run_id
+                )
+            else:
+                raise TypeError("Please ensure that the logger is a `MLFlowLogger` with `artifact_location` or `save_dir` set.")
 
-            dir_run.mkdir(exist_ok=True)
+            path_config = dir_run / self.config_filename
+            dir_run.mkdir(exist_ok=True, parents=True)
 
             self.parser.save(
                 self.config,


### PR DESCRIPTION
Fix `MLFlowConfigCallback` to work with both `_artifact_location` and `save_dir` attributes.